### PR TITLE
fix: screensaver weather+status block bounds checking

### DIFF
--- a/src/thermostat/ui/thermostat_ui_shared.cpp
+++ b/src/thermostat/ui/thermostat_ui_shared.cpp
@@ -1091,10 +1091,10 @@ void update_screensaver_layout(lv_obj_t *time_label, lv_obj_t *weather_label, lv
 
   lv_obj_set_pos(time_label, margin, margin);
   lv_obj_set_pos(weather_label, margin, margin + time_h + 20);
-  lv_obj_set_pos(indoor_label, margin, margin + time_h + weather_h + 40);
   if (status_label != nullptr) {
-    lv_obj_set_pos(status_label, margin, margin + time_h + weather_h + 28);
+    lv_obj_set_pos(status_label, margin, margin + time_h + 20 + weather_h + 4);
   }
+  lv_obj_set_pos(indoor_label, margin, margin + time_h + 20 + weather_block_h + 20);
 }
 
 }  // namespace ui


### PR DESCRIPTION
## Summary
- The screensaver status label (rendered below the weather label with a 4px gap) was not included in `fits()`/`intersects()` bounds checks, causing it to render partially off-screen
- Now computes a combined weather+status block size and uses it for all candidate layout positioning and collision detection

## Test plan
- [x] Native tests pass (72/72)
- [ ] Visual verification on device or simulator that the weather+status block stays fully on-screen across all screensaver layout positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)