### PR TITLE
fix: prevent display packed_command from blocking MQTT commands

### DIFF
--- a/src/esp32_controller_main.cpp
+++ b/src/esp32_controller_main.cpp
@@ -1730,8 +1730,10 @@ void ctrl_mqtt_on_message(char *topic, uint8_t *payload, unsigned int length) {
           char formatted_mac[18];
           uint8_t src_mac[6];
           const uint8_t *mac_ptr = nullptr;
-          if (format_mac_colons(peer_mac.c_str(), formatted_mac, sizeof(formatted_mac)) &&
-              ctrl_parse_mac(formatted_mac, src_mac)) {
+          // format_mac_colons copies even when it returns false (already
+          // colon-formatted), so ignore its return value.
+          format_mac_colons(peer_mac.c_str(), formatted_mac, sizeof(formatted_mac));
+          if (ctrl_parse_mac(formatted_mac, src_mac)) {
             mac_ptr = src_mac;
           }
           ctrl_apply_packed_command(packed, true, mac_ptr);

--- a/src/esp32_controller_main.cpp
+++ b/src/esp32_controller_main.cpp
@@ -1725,9 +1725,16 @@ void ctrl_mqtt_on_message(char *topic, uint8_t *payload, unsigned int length) {
         if (!g_cfg_ctrl_allow_ha || !g_cfg_ctrl_mqtt_enabled) return;
         uint32_t packed = 0;
         if (ctrl_parse_u32_payload(value, &packed)) {
-          // Short MAC in topic path can't be parsed by ctrl_parse_mac;
-          // pass nullptr — MQTT auth is handled differently from ESP-NOW.
-          ctrl_apply_packed_command(packed, true, nullptr);
+          // Parse peer MAC so this source gets its own sequence tracker,
+          // separate from direct MQTT cmd/* commands.
+          char formatted_mac[18];
+          uint8_t src_mac[6];
+          const uint8_t *mac_ptr = nullptr;
+          if (format_mac_colons(peer_mac.c_str(), formatted_mac, sizeof(formatted_mac)) &&
+              ctrl_parse_mac(formatted_mac, src_mac)) {
+            mac_ptr = src_mac;
+          }
+          ctrl_apply_packed_command(packed, true, mac_ptr);
         }
         return;
       }
@@ -1818,6 +1825,7 @@ void ctrl_mqtt_on_message(char *topic, uint8_t *payload, unsigned int length) {
     if (g_ctrl_temp_unit_f) sp = (sp - 32.0f) * 5.0f / 9.0f;
     if (sp < 0.0f) sp = 0.0f;
     if (sp > 40.0f) sp = 40.0f;
+    sp = roundf(sp * 2.0f) / 2.0f;  // snap to 0.5C step
     g_ctrl_shadow_setpoint_c = sp;
     g_ctrl_have_shadow = true;
     ctrl_apply_mqtt_shadow(false, false);

--- a/src/tests/test_controller_runtime.cpp
+++ b/src/tests/test_controller_runtime.cpp
@@ -507,4 +507,35 @@ TEST_CASE(controller_runtime_null_source_uses_default_sequence) {
   cmd.seq = 5;
   ASSERT_TRUE(rt.apply_remote_command(cmd, mac_a).accepted);
 }
+
+TEST_CASE(controller_runtime_display_mac_does_not_block_mqtt_commands) {
+  // Regression: display's packed_command (with MAC) advancing seq should not
+  // block direct MQTT cmd/* commands (nullptr source).
+  thermostat::ControllerRuntime rt;
+
+  const uint8_t display_mac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+
+  // Display sends many commands, advancing its sequence far ahead
+  CommandWord cmd;
+  for (uint8_t i = 1; i <= 50; ++i) {
+    cmd.seq = i;
+    cmd.mode = FurnaceMode::Heat;
+    cmd.setpoint_decic = 210;
+    ASSERT_TRUE(rt.apply_remote_command(cmd, display_mac).accepted);
+  }
+
+  // Direct MQTT command with low seq via nullptr — must still be accepted
+  cmd.seq = 1;
+  cmd.mode = FurnaceMode::Cool;
+  cmd.setpoint_decic = 240;
+  ASSERT_TRUE(rt.apply_remote_command(cmd, nullptr).accepted);
+
+  // Second direct MQTT command with seq=2 — also accepted
+  cmd.seq = 2;
+  ASSERT_TRUE(rt.apply_remote_command(cmd, nullptr).accepted);
+
+  // But duplicate on nullptr is still rejected
+  cmd.seq = 2;
+  ASSERT_TRUE(rt.apply_remote_command(cmd, nullptr).stale_or_duplicate);
+}
 #endif


### PR DESCRIPTION
## Summary

- **Root cause:** Display's `state/packed_command` was processed with `source_mac=nullptr`, sharing the sequence tracker with direct MQTT `cmd/*` commands. The display's sequence numbers advanced far ahead, causing all subsequent direct MQTT commands to be silently rejected as stale.
- **Fix:** Pass the display's peer MAC when processing `state/packed_command` so it gets its own per-source sequence tracker slot, independent from direct MQTT commands.
- **Bonus:** Round incoming setpoints to nearest 0.5C to match `temp_step` (HA can send unrounded values like `20.555555` when converting 69F).

Closes #19

## Test plan

- [x] New test `controller_runtime_display_mac_does_not_block_mqtt_commands` — verifies display MAC advancing seq to 50 doesn't block nullptr commands
- [x] All 73 native tests pass
- [x] Controller firmware builds successfully
- [ ] Deploy to controller and verify MQTT commands apply correctly via HA

🤖 Generated with [Claude Code](https://claude.com/claude-code)