### PR TITLE
feat: windows-open A/C disable

### DIFF
--- a/docs/superpowers/plans/2026-05-12-windows-open-ac-disable.md
+++ b/docs/superpowers/plans/2026-05-12-windows-open-ac-disable.md
@@ -1,0 +1,1004 @@
+# Windows Open A/C Disable — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `windows_open` boolean state, driven by Home Assistant over MQTT, that suppresses cooling demand only. Display shows "Windows Open" in status text when active mode is Cool.
+
+**Architecture:** New `windows_open_` field on `ControllerRuntime` mirroring the `hvac_lockout` plumbing pattern. Cooling suppression is implemented by forcing `cool_call = false` at the top of `apply_hvac_calls`, after the failsafe/lockout early-return — so existing min-run-time logic naturally finishes any active cooling cycle before idling. Wire transport: MQTT topic `cmd/windows_open` for HA, JSON field in retained state, and a single repurposed bit in the existing ESP-NOW `lockout` byte (bit 0 = lockout, bit 1 = windows_open) to avoid a protocol-version bump. Display parses both sources and `furnace_state_text` returns "Windows Open" only when active mode is Cool and no higher-priority state is present.
+
+**Tech Stack:** C++ / Arduino / ESP-IDF (ESP32), PlatformIO, LVGL (display), MQTT (PubSubClient), ESP-NOW.
+
+**Spec:** [`docs/superpowers/specs/2026-05-12-windows-open-ac-disable-design.md`](../specs/2026-05-12-windows-open-ac-disable-design.md)
+
+---
+
+## Task 1: Add `windows_open` to shared snapshot type and `ControllerRuntime`
+
+Adds the field, accessors, and the cooling-suppression branch in `apply_hvac_calls`. Drives the change with native unit tests in `test_controller_runtime.cpp`.
+
+**Files:**
+- Modify: `include/thermostat_types.h`
+- Modify: `include/controller/controller_runtime.h`
+- Modify: `src/controller/controller_runtime.cpp`
+- Modify: `src/tests/test_controller_runtime.cpp`
+
+- [ ] **Step 1: Write failing test — cool_call is suppressed when windows_open is set**
+
+Append to `src/tests/test_controller_runtime.cpp`:
+
+```cpp
+TEST_CASE(controller_runtime_windows_open_suppresses_cooling) {
+  thermostat::ControllerConfig cfg;
+  cfg.failsafe_timeout_ms = 1000000;
+  cfg.min_idle_time_ms = 0;
+  cfg.min_cooling_off_time_ms = 0;
+  cfg.min_cooling_run_time_ms = 0;
+  thermostat::ControllerRuntime rt(cfg);
+  rt.note_heartbeat(1);
+
+  // Put runtime in Cool mode via remote command
+  CommandWord cmd;
+  cmd.mode = FurnaceMode::Cool;
+  cmd.seq = 1;
+  ASSERT_TRUE(rt.apply_remote_command(cmd).accepted);
+
+  // Without windows_open, cool_call drives cool demand
+  thermostat::ControllerTickInput t1;
+  t1.now_ms = 1000;
+  t1.cool_call = true;
+  t1.has_indoor_temp = true;
+  rt.tick(t1);
+  ASSERT_TRUE(rt.cool_demand());
+
+  // Snapshot reflects windows_open=false initially
+  ASSERT_TRUE(!rt.snapshot().windows_open);
+
+  // Activate windows_open — cool demand must drop (no min-run configured)
+  rt.set_windows_open(true);
+  thermostat::ControllerTickInput t2;
+  t2.now_ms = 2000;
+  t2.cool_call = true;
+  t2.has_indoor_temp = true;
+  rt.tick(t2);
+  ASSERT_TRUE(rt.windows_open());
+  ASSERT_TRUE(rt.snapshot().windows_open);
+  ASSERT_TRUE(!rt.cool_demand());
+
+  // Clearing windows_open re-enables cooling
+  rt.set_windows_open(false);
+  thermostat::ControllerTickInput t3;
+  t3.now_ms = 3000;
+  t3.cool_call = true;
+  t3.has_indoor_temp = true;
+  rt.tick(t3);
+  ASSERT_TRUE(rt.cool_demand());
+}
+
+TEST_CASE(controller_runtime_windows_open_does_not_block_heat) {
+  thermostat::ControllerConfig cfg;
+  cfg.failsafe_timeout_ms = 1000000;
+  cfg.min_idle_time_ms = 0;
+  cfg.min_heating_off_time_ms = 0;
+  cfg.min_heating_run_time_ms = 0;
+  thermostat::ControllerRuntime rt(cfg);
+  rt.note_heartbeat(1);
+
+  CommandWord cmd;
+  cmd.mode = FurnaceMode::Heat;
+  cmd.seq = 1;
+  ASSERT_TRUE(rt.apply_remote_command(cmd).accepted);
+
+  rt.set_windows_open(true);
+  thermostat::ControllerTickInput t1;
+  t1.now_ms = 1000;
+  t1.heat_call = true;
+  t1.has_indoor_temp = true;
+  rt.tick(t1);
+  ASSERT_TRUE(rt.heat_demand());
+}
+
+TEST_CASE(controller_runtime_windows_open_honors_cool_min_run_time) {
+  thermostat::ControllerConfig cfg;
+  cfg.failsafe_timeout_ms = 1000000;
+  cfg.min_idle_time_ms = 0;
+  cfg.min_cooling_off_time_ms = 0;
+  cfg.min_cooling_run_time_ms = 60000;  // 60s
+  thermostat::ControllerRuntime rt(cfg);
+  rt.note_heartbeat(1);
+
+  CommandWord cmd;
+  cmd.mode = FurnaceMode::Cool;
+  cmd.seq = 1;
+  ASSERT_TRUE(rt.apply_remote_command(cmd).accepted);
+
+  // Enter cooling
+  thermostat::ControllerTickInput t1;
+  t1.now_ms = 1000;
+  t1.cool_call = true;
+  t1.has_indoor_temp = true;
+  rt.tick(t1);
+  ASSERT_TRUE(rt.cool_demand());
+
+  // Windows open while min_run not yet elapsed — still cooling
+  rt.set_windows_open(true);
+  thermostat::ControllerTickInput t2;
+  t2.now_ms = 30000;
+  t2.cool_call = true;  // upstream still requesting
+  t2.has_indoor_temp = true;
+  rt.tick(t2);
+  ASSERT_TRUE(rt.cool_demand());
+
+  // After min_run elapses, cooling idles
+  thermostat::ControllerTickInput t3;
+  t3.now_ms = 70000;
+  t3.cool_call = true;
+  t3.has_indoor_temp = true;
+  rt.tick(t3);
+  ASSERT_TRUE(!rt.cool_demand());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pio run -e native-tests && .pio/build/native-tests/program`
+Expected: 3 new test cases fail with compile error — `windows_open`, `set_windows_open`, and `ThermostatSnapshot::windows_open` not declared.
+
+- [ ] **Step 3: Add `windows_open` to `ThermostatSnapshot`**
+
+In `include/thermostat_types.h`, modify the snapshot struct:
+
+```cpp
+struct ThermostatSnapshot {
+  FurnaceMode mode = FurnaceMode::Off;
+  FanMode fan_mode = FanMode::Automatic;
+  RelayDemand relay{};
+  bool hvac_lockout = false;
+  bool failsafe_active = false;
+  bool windows_open = false;
+};
+```
+
+- [ ] **Step 4: Add `windows_open_` field and accessors to `ControllerRuntime`**
+
+In `include/controller/controller_runtime.h`, after `void set_hvac_lockout(bool locked_out);` (around line 52) add:
+
+```cpp
+  void set_windows_open(bool open);
+```
+
+After `bool hvac_lockout() const { return hvac_lockout_; }` (around line 71) add:
+
+```cpp
+  bool windows_open() const { return windows_open_; }
+```
+
+In the private members section, after `bool hvac_lockout_ = false;` (around line 114) add:
+
+```cpp
+  bool windows_open_ = false;
+```
+
+- [ ] **Step 5: Implement `set_windows_open` and snapshot population**
+
+In `src/controller/controller_runtime.cpp`, after the `set_hvac_lockout` function (around line 61), add:
+
+```cpp
+void ControllerRuntime::set_windows_open(bool open) {
+  if (open != windows_open_) {
+    audit("windows_open: %s [internal]", open ? "on" : "off");
+  }
+  windows_open_ = open;
+}
+```
+
+In `ControllerRuntime::snapshot()` (around line 208–215), add the new field:
+
+```cpp
+ThermostatSnapshot ControllerRuntime::snapshot() const {
+  ThermostatSnapshot s;
+  s.mode = mode_;
+  s.fan_mode = fan_mode_;
+  s.relay = relay_;
+  s.hvac_lockout = hvac_lockout_;
+  s.failsafe_active = failsafe_active_;
+  s.windows_open = windows_open_;
+  return s;
+}
+```
+
+- [ ] **Step 6: Suppress `cool_call` in `apply_hvac_calls`**
+
+In `src/controller/controller_runtime.cpp`, in `apply_hvac_calls` (around line 248), modify the function so that immediately after the `failsafe_active_ || hvac_lockout_` early-return block, the parameter `cool_call` is forced false when windows are open. Because `cool_call` is a value parameter, we mutate the local copy.
+
+Find:
+
+```cpp
+void ControllerRuntime::apply_hvac_calls(uint32_t now_ms, bool heat_call, bool cool_call) {
+  if (failsafe_active_ || hvac_lockout_) {
+    enter_idle(now_ms);
+    relay_.fan = false;
+    equipment_delay_ = false;
+    return;
+  }
+
+  switch (hvac_state_) {
+```
+
+Replace with:
+
+```cpp
+void ControllerRuntime::apply_hvac_calls(uint32_t now_ms, bool heat_call, bool cool_call) {
+  if (failsafe_active_ || hvac_lockout_) {
+    enter_idle(now_ms);
+    relay_.fan = false;
+    equipment_delay_ = false;
+    return;
+  }
+
+  if (windows_open_) {
+    cool_call = false;
+  }
+
+  switch (hvac_state_) {
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `pio run -e native-tests && .pio/build/native-tests/program`
+Expected: All tests pass, including the three new windows_open cases.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add include/thermostat_types.h include/controller/controller_runtime.h \
+        src/controller/controller_runtime.cpp src/tests/test_controller_runtime.cpp
+git commit -m "feat(controller): add windows_open state suppressing cooling demand"
+```
+
+---
+
+## Task 2: Expose `windows_open` through `ControllerApp` and telemetry struct
+
+Adds the app-level pass-through and surfaces the flag on outgoing telemetry so MQTT and ESP-NOW publishers can carry it. Includes change-detection so telemetry republishes when the flag flips.
+
+**Files:**
+- Modify: `include/controller/controller_app.h`
+- Modify: `src/controller/controller_app.cpp`
+
+- [ ] **Step 1: Add `windows_open` to `ControllerTelemetry`**
+
+In `include/controller/controller_app.h`, around line 11–19, add a new field at the end of the struct:
+
+```cpp
+struct ControllerTelemetry {
+  uint16_t seq = 0;
+  FurnaceStateCode state = FurnaceStateCode::Error;
+  float filter_runtime_hours = 0.0f;
+  bool lockout = false;
+  uint8_t mode_code = 0;  // off=0, heat=1, cool=2
+  uint8_t fan_code = 0;   // auto=0, on=1, circulate=2
+  float setpoint_c = 0.0f;
+  bool windows_open = false;
+};
+```
+
+- [ ] **Step 2: Add `set_windows_open` method on `ControllerApp`**
+
+In `include/controller/controller_app.h`, after `void set_hvac_lockout(bool locked);` (around line 41), add:
+
+```cpp
+  void set_windows_open(bool open);
+```
+
+- [ ] **Step 3: Implement `set_windows_open` pass-through**
+
+In `src/controller/controller_app.cpp`, after the `set_hvac_lockout` function (around line 73–76), add:
+
+```cpp
+void ControllerApp::set_windows_open(bool open) {
+  runtime_.set_windows_open(open);
+  publish();
+}
+```
+
+- [ ] **Step 4: Populate `windows_open` in `publish()` and update change detection**
+
+In `src/controller/controller_app.cpp`, modify `telemetry_payload_changed` (around line 37–45) to include the new field:
+
+```cpp
+bool ControllerApp::telemetry_payload_changed(const ControllerTelemetry &next) const {
+  if (!has_last_published_) {
+    return true;
+  }
+  return next.state != last_published_.state ||
+         next.filter_runtime_hours != last_published_.filter_runtime_hours ||
+         next.lockout != last_published_.lockout || next.mode_code != last_published_.mode_code ||
+         next.fan_code != last_published_.fan_code || next.setpoint_c != last_published_.setpoint_c ||
+         next.windows_open != last_published_.windows_open;
+}
+```
+
+In `publish()` (around line 202–224), populate the new field. Find:
+
+```cpp
+  t.lockout = runtime_.hvac_lockout();
+  t.mode_code = mode_to_code(runtime_.mode());
+  t.fan_code = fan_to_code(runtime_.fan_mode());
+  t.setpoint_c = runtime_.target_temperature_c();
+```
+
+Add after the last line:
+
+```cpp
+  t.windows_open = runtime_.windows_open();
+```
+
+- [ ] **Step 5: Run native tests to verify nothing regressed**
+
+Run: `pio run -e native-tests && .pio/build/native-tests/program`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add include/controller/controller_app.h src/controller/controller_app.cpp
+git commit -m "feat(controller): plumb windows_open through ControllerApp and telemetry"
+```
+
+---
+
+## Task 3: Carry `windows_open` over ESP-NOW (bit-packed in existing `lockout` byte)
+
+Avoids a protocol version bump by using bit 1 of the `lockout` byte for `windows_open` (bit 0 remains the lockout flag). Receivers running older firmware see the windows_open bit as garbage in `lockout`, so the encoder MUST encode only the boolean in bit 0 and bit 1 — no other bits. Decoders MUST mask `& 0x01` for lockout. Old senders set bit 1 to 0, so new receivers see windows_open=false from old senders, which is the safe default.
+
+**Files:**
+- Modify: `include/thermostat/transport/espnow_thermostat_transport.h`
+- Modify: `src/controller/transport/espnow_controller_transport.cpp`
+- Modify: `src/thermostat/transport/espnow_thermostat_transport.cpp`
+
+- [ ] **Step 1: Add `windows_open` to `ThermostatControllerTelemetry`**
+
+In `include/thermostat/transport/espnow_thermostat_transport.h`, modify the struct around lines 13–21:
+
+```cpp
+struct ThermostatControllerTelemetry {
+  uint16_t seq = 0;
+  FurnaceStateCode state = FurnaceStateCode::Error;
+  bool lockout = false;
+  uint8_t mode_code = 0;
+  uint8_t fan_code = 0;
+  float setpoint_c = 0.0f;
+  uint32_t filter_runtime_seconds = 0;
+  bool windows_open = false;
+};
+```
+
+- [ ] **Step 2: Encode windows_open in lockout byte on the controller transmitter**
+
+In `src/controller/transport/espnow_controller_transport.cpp` `publish_telemetry` (around line 153), find:
+
+```cpp
+  pkt.lockout = telemetry.lockout ? 1 : 0;
+```
+
+Replace with:
+
+```cpp
+  pkt.lockout = static_cast<uint8_t>((telemetry.lockout ? 0x01 : 0x00) |
+                                     (telemetry.windows_open ? 0x02 : 0x00));
+```
+
+- [ ] **Step 3: Decode bit fields on the display receiver**
+
+In `src/thermostat/transport/espnow_thermostat_transport.cpp` `on_recv` (around line 220), find:
+
+```cpp
+        telemetry.lockout = pkt->lockout != 0;
+```
+
+Replace with:
+
+```cpp
+        telemetry.lockout = (pkt->lockout & 0x01) != 0;
+        telemetry.windows_open = (pkt->lockout & 0x02) != 0;
+```
+
+- [ ] **Step 4: Wire windows_open through the controller transport caller**
+
+We also need the controller's `ControllerNode` (the layer that builds `ControllerTelemetry`-equivalent data for the transport) to populate the new field. Find the call sites that build the transport's telemetry struct:
+
+Run: `grep -rn "publish_telemetry\|ControllerTelemetry t\|ControllerTelemetry tel" src/controller include/controller`
+
+Find the location that constructs a `ControllerTelemetry` for transport (already happens in `ControllerApp::publish()` from Task 2). Confirm `ControllerApp::publish()` passes the struct to `transport_.publish_telemetry(t)` — it does. Since `IControllerTransport::publish_telemetry` accepts the same `ControllerTelemetry` struct that now has `windows_open`, no further wiring is needed on the controller send side.
+
+On the display, the transport currently calls back with `ThermostatControllerTelemetry` which now also carries `windows_open`. Confirm by reading.
+
+Run: `grep -rn "on_telemetry\b\|ThermostatControllerTelemetry" src/thermostat include/thermostat | head`
+Expected: `ThermostatNode::on_telemetry` and `ThermostatApp::on_controller_telemetry` are the consumers. We'll update `ThermostatApp` in Task 5.
+
+- [ ] **Step 5: Build native tests and both firmware envs to verify compile**
+
+Run: `pio run -e native-tests`
+Run: `pio run -e esp32-furnace-controller`
+Run: `pio run -e esp32-furnace-thermostat`
+Expected: All three builds succeed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add include/thermostat/transport/espnow_thermostat_transport.h \
+        src/controller/transport/espnow_controller_transport.cpp \
+        src/thermostat/transport/espnow_thermostat_transport.cpp
+git commit -m "feat(transport): carry windows_open in ESP-NOW lockout byte (bit 1)"
+```
+
+---
+
+## Task 4: Controller MQTT — command topic, retained state, discovery, status page
+
+Mirrors the existing `cmd/lockout` plumbing: subscribe to `cmd/windows_open`, publish retained `state/windows_open`, publish HA discovery for a `switch` entity, add to the JSON status payload, and add a row on the status page.
+
+**Files:**
+- Modify: `src/esp32_controller_main.cpp`
+
+- [ ] **Step 1: Add MQTT command handler for `cmd/windows_open`**
+
+In `src/esp32_controller_main.cpp`, around line 1873–1892, find the lockout command block:
+
+```cpp
+  // Block lockout and HVAC commands when HA is not allowed
+  if (!ha_allowed) {
+    if (topic_str == self_topic_for("cmd/lockout") ||
+        topic_str == self_topic_for("cmd/mode") ||
+```
+
+Modify the gate list to also block `cmd/windows_open`:
+
+```cpp
+  if (!ha_allowed) {
+    if (topic_str == self_topic_for("cmd/lockout") ||
+        topic_str == self_topic_for("cmd/windows_open") ||
+        topic_str == self_topic_for("cmd/mode") ||
+```
+
+Then, immediately after the existing `if (topic_str == self_topic_for("cmd/lockout"))` block (which ends with `return;` around line 1892), add:
+
+```cpp
+  if (topic_str == self_topic_for("cmd/windows_open")) {
+    const bool new_value = mqtt_payload::parse_bool(value);
+    ctrl_audit("windows_open: %s [mqtt]", new_value ? "on" : "off");
+    g_controller->app().set_windows_open(new_value);
+    ctrl_publish_runtime_state();
+    return;
+  }
+```
+
+- [ ] **Step 2: Subscribe to the new command topic on MQTT connect**
+
+In `src/esp32_controller_main.cpp` around line 2035–2046, find the `subs_ok` chain. Modify to add the new subscription right after the `cmd/lockout` line:
+
+```cpp
+  const bool subs_ok =
+      g_ctrl_mqtt.subscribe(self_topic_for("cmd/lockout").c_str()) &&
+      g_ctrl_mqtt.subscribe(self_topic_for("cmd/windows_open").c_str()) &&
+      g_ctrl_mqtt.subscribe(self_topic_for("cmd/mode").c_str()) &&
+```
+
+- [ ] **Step 3: Publish retained state**
+
+In `src/esp32_controller_main.cpp` `ctrl_publish_runtime_state()` around line 1586, find:
+
+```cpp
+  g_ctrl_mqtt.publish(self_topic_for("state/lockout").c_str(), lockout ? "1" : "0", true);
+```
+
+Add the new publish immediately after:
+
+```cpp
+  g_ctrl_mqtt.publish(self_topic_for("state/windows_open").c_str(),
+                      rt.windows_open() ? "1" : "0", true);
+```
+
+- [ ] **Step 4: Add HA discovery for the windows_open switch**
+
+In `ctrl_publish_discovery()` around line 808, add a new topic constant near the lockout one:
+
+```cpp
+  const String switch_topic = dp + "switch/" + dev_id + "_lockout/config";
+  const String windows_open_topic = dp + "switch/" + dev_id + "_windows_open/config";
+```
+
+Then, after the lockout switch payload publish (around line 865–870), add:
+
+```cpp
+  snprintf(payload, sizeof(payload),
+           "{\"name\":\"Windows Open\",\"uniq_id\":\"%s_windows_open\","
+           "\"cmd_t\":\"%s/cmd/windows_open\","
+           "\"stat_t\":\"%s/state/windows_open\",\"pl_on\":\"1\",\"pl_off\":\"0\","
+           "\"dev\":{\"ids\":[\"%s\"]}}",
+           dev_id.c_str(), base.c_str(), base.c_str(), dev_id.c_str());
+  g_ctrl_mqtt.publish(windows_open_topic.c_str(), payload, true);
+```
+
+- [ ] **Step 5: Add JSON field to status payload**
+
+In the runtime status JSON formatter around line 1207–1208, find:
+
+```cpp
+    "\"hvac_lockout\":%s,"
+    "\"failsafe_active\":%s,"
+```
+
+Insert after `hvac_lockout`:
+
+```cpp
+    "\"hvac_lockout\":%s,"
+    "\"windows_open\":%s,"
+    "\"failsafe_active\":%s,"
+```
+
+Then in the matching `snprintf` arg list around line 1237–1238, find:
+
+```cpp
+    rt.hvac_lockout() ? "true" : "false",
+    rt.failsafe_active() ? "true" : "false",
+```
+
+Insert the new argument between them:
+
+```cpp
+    rt.hvac_lockout() ? "true" : "false",
+    rt.windows_open() ? "true" : "false",
+    rt.failsafe_active() ? "true" : "false",
+```
+
+- [ ] **Step 6: Add status-page row**
+
+In `src/esp32_controller_main.cpp` around line 1314, find:
+
+```cpp
+  status_item(html, "HVAC Lockout", "hvac_lockout");
+```
+
+Add immediately after:
+
+```cpp
+  status_item(html, "Windows Open", "windows_open");
+```
+
+- [ ] **Step 7: Build controller firmware**
+
+Run: `pio run -e esp32-furnace-controller`
+Expected: build succeeds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/esp32_controller_main.cpp
+git commit -m "feat(controller): MQTT command, state, discovery, and status row for windows_open"
+```
+
+---
+
+## Task 5: Display — parse `windows_open` from MQTT and ESP-NOW, store in app state
+
+Adds the field on `ThermostatApp` and the two paths that populate it: ESP-NOW telemetry (`on_controller_telemetry`) and the MQTT state-update bridge (`on_controller_state_update`).
+
+**Files:**
+- Modify: `include/thermostat/thermostat_app.h`
+- Modify: `src/thermostat/thermostat_app.cpp`
+- Modify: `src/esp32_thermostat_main.cpp`
+
+- [ ] **Step 1: Add `controller_windows_open_` field and accessor to `ThermostatApp`**
+
+In `include/thermostat/thermostat_app.h`, around line 56, after:
+
+```cpp
+  bool controller_lockout() const { return controller_lockout_; }
+```
+
+Add:
+
+```cpp
+  bool controller_windows_open() const { return controller_windows_open_; }
+```
+
+Around line 93, after:
+
+```cpp
+  bool controller_lockout_ = false;
+```
+
+Add:
+
+```cpp
+  bool controller_windows_open_ = false;
+```
+
+- [ ] **Step 2: Update `on_controller_telemetry` signature is unchanged but body populates the new field**
+
+In `src/thermostat/thermostat_app.cpp` `on_controller_telemetry` around line 54, find:
+
+```cpp
+  controller_lockout_ = telemetry.lockout;
+```
+
+Add immediately after:
+
+```cpp
+  controller_windows_open_ = telemetry.windows_open;
+```
+
+- [ ] **Step 3: Extend `on_controller_state_update` to accept `windows_open`**
+
+In `include/thermostat/thermostat_app.h`, find the declaration of `on_controller_state_update` and add a `bool windows_open` parameter at the end. Locate it via:
+
+Run: `grep -n "on_controller_state_update" include/thermostat/thermostat_app.h`
+
+Modify the declaration to:
+
+```cpp
+  void on_controller_state_update(uint32_t now_ms, FurnaceStateCode state, bool lockout,
+                                  FurnaceMode mode, FanMode fan, float setpoint_c,
+                                  uint32_t filter_runtime_seconds, bool windows_open);
+```
+
+In `src/thermostat/thermostat_app.cpp` around line 74–84, update the definition and body:
+
+```cpp
+void ThermostatApp::on_controller_state_update(
+    uint32_t now_ms, FurnaceStateCode state, bool lockout, FurnaceMode mode,
+    FanMode fan, float setpoint_c, uint32_t filter_runtime_seconds, bool windows_open) {
+  on_controller_heartbeat(now_ms);
+
+  has_controller_telemetry_ = true;
+  controller_state_ = state;
+  controller_lockout_ = lockout;
+  controller_windows_open_ = windows_open;
+  controller_setpoint_c_ = setpoint_c;
+  controller_filter_runtime_seconds_ = filter_runtime_seconds;
+```
+
+- [ ] **Step 4: Update all call sites of `on_controller_state_update`**
+
+Run: `grep -rn "on_controller_state_update" src include`
+For each call site (likely in `src/esp32_thermostat_main.cpp` and test files), add a final argument carrying the parsed `windows_open` value from the controller's MQTT state JSON / `state/windows_open` retained topic.
+
+In `src/esp32_thermostat_main.cpp`, locate the parser that reads `state/lockout`. Mirror it with a parser for `state/windows_open`. For example:
+
+Run: `grep -n "state/lockout\b" src/esp32_thermostat_main.cpp`
+
+For each match: add a parallel branch for `state/windows_open` that stores the parsed bool in a local variable used in the subsequent `app_.on_controller_state_update(...)` call. If `on_controller_state_update` is called from multiple places, ensure a `bool g_disp_controller_windows_open = false;` global (or struct field) holds the most recent value and is passed to every call site.
+
+- [ ] **Step 5: Update test call sites of `on_controller_state_update` and `ThermostatControllerTelemetry`**
+
+Run: `grep -rn "on_controller_state_update\|ThermostatControllerTelemetry " src/tests`
+
+For each match, add the new field. For struct literals add `telem.windows_open = false;` where appropriate. For function calls add the final argument `false` unless the test specifically wants to exercise the windows_open path.
+
+- [ ] **Step 6: Build native tests and both firmwares**
+
+Run: `pio run -e native-tests && .pio/build/native-tests/program`
+Run: `pio run -e esp32-furnace-controller`
+Run: `pio run -e esp32-furnace-thermostat`
+Expected: all builds succeed, all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add include/thermostat/thermostat_app.h src/thermostat/thermostat_app.cpp \
+        src/esp32_thermostat_main.cpp src/tests/
+git commit -m "feat(display): track controller windows_open via ESP-NOW and MQTT"
+```
+
+---
+
+## Task 6: Display status text — "Windows Open" when in Cool mode
+
+Updates `furnace_state_text` to accept the windows_open flag and the active mode. Returns "Windows Open" only when active mode is Cool, windows_open is true, and no higher-priority state (Failsafe, Locked Out, Not Connected) is present.
+
+**Files:**
+- Modify: `include/thermostat/thermostat_ui_state.h`
+- Modify: `src/thermostat/thermostat_ui_state.cpp`
+- Modify: `src/thermostat/thermostat_display_app.cpp`
+- Modify: `src/tests/` (add a new test file for thermostat_ui_state or extend existing)
+
+- [ ] **Step 1: Identify or create the test file for thermostat_ui_state**
+
+Run: `ls src/tests/ | grep ui_state`
+If no test file exists, create `src/tests/test_thermostat_ui_state.cpp`. Otherwise extend the existing file.
+
+- [ ] **Step 2: Write failing tests for status text**
+
+Add to `src/tests/test_thermostat_ui_state.cpp` (create if missing):
+
+```cpp
+#if defined(THERMOSTAT_RUN_TESTS)
+#include "thermostat/thermostat_ui_state.h"
+#include "test_harness.h"
+
+TEST_CASE(furnace_state_text_windows_open_in_cool_mode) {
+  std::string s = thermostat::furnace_state_text(
+      FurnaceStateCode::CoolMode, /*connected=*/true, /*lockout=*/false,
+      /*failsafe_active=*/false, /*windows_open=*/true, FurnaceMode::Cool);
+  ASSERT_STR_EQ(s.c_str(), "Windows Open");
+}
+
+TEST_CASE(furnace_state_text_windows_open_ignored_in_heat_mode) {
+  std::string s = thermostat::furnace_state_text(
+      FurnaceStateCode::HeatMode, /*connected=*/true, /*lockout=*/false,
+      /*failsafe_active=*/false, /*windows_open=*/true, FurnaceMode::Heat);
+  ASSERT_STR_EQ(s.c_str(), "Heat mode");
+}
+
+TEST_CASE(furnace_state_text_windows_open_ignored_in_off_mode) {
+  std::string s = thermostat::furnace_state_text(
+      FurnaceStateCode::Idle, /*connected=*/true, /*lockout=*/false,
+      /*failsafe_active=*/false, /*windows_open=*/true, FurnaceMode::Off);
+  ASSERT_STR_EQ(s.c_str(), "Idle");
+}
+
+TEST_CASE(furnace_state_text_failsafe_overrides_windows_open) {
+  std::string s = thermostat::furnace_state_text(
+      FurnaceStateCode::CoolMode, /*connected=*/true, /*lockout=*/false,
+      /*failsafe_active=*/true, /*windows_open=*/true, FurnaceMode::Cool);
+  ASSERT_STR_EQ(s.c_str(), "Failsafe");
+}
+
+TEST_CASE(furnace_state_text_lockout_overrides_windows_open) {
+  std::string s = thermostat::furnace_state_text(
+      FurnaceStateCode::CoolMode, /*connected=*/true, /*lockout=*/true,
+      /*failsafe_active=*/false, /*windows_open=*/true, FurnaceMode::Cool);
+  ASSERT_STR_EQ(s.c_str(), "Locked Out");
+}
+
+TEST_CASE(furnace_state_text_disconnected_overrides_windows_open) {
+  std::string s = thermostat::furnace_state_text(
+      FurnaceStateCode::CoolMode, /*connected=*/false, /*lockout=*/false,
+      /*failsafe_active=*/false, /*windows_open=*/true, FurnaceMode::Cool);
+  ASSERT_STR_EQ(s.c_str(), "Not Connected");
+}
+
+TEST_CASE(furnace_state_text_no_windows_open_returns_normal) {
+  std::string s = thermostat::furnace_state_text(
+      FurnaceStateCode::CoolOn, /*connected=*/true, /*lockout=*/false,
+      /*failsafe_active=*/false, /*windows_open=*/false, FurnaceMode::Cool);
+  ASSERT_STR_EQ(s.c_str(), "Cool on");
+}
+#endif
+```
+
+If creating the file, also add it to `platformio.ini` test sources if the project uses an explicit list — check by running:
+
+Run: `grep -n "test_thermostat" platformio.ini`
+Most likely tests are auto-discovered from `src/tests/`. If so, no `platformio.ini` change is needed.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pio run -e native-tests && .pio/build/native-tests/program`
+Expected: Compile error — `furnace_state_text` doesn't accept the additional arguments.
+
+- [ ] **Step 4: Update `furnace_state_text` signature**
+
+In `include/thermostat/thermostat_ui_state.h` (around line 9–13), update the declaration:
+
+```cpp
+std::string furnace_state_text(FurnaceStateCode state,
+                               bool connected,
+                               bool lockout,
+                               bool failsafe_active,
+                               bool windows_open,
+                               FurnaceMode mode);
+```
+
+In `src/thermostat/thermostat_ui_state.cpp`, update the definition (around lines 5–39) to:
+
+```cpp
+std::string furnace_state_text(FurnaceStateCode state,
+                               bool connected,
+                               bool lockout,
+                               bool failsafe_active,
+                               bool windows_open,
+                               FurnaceMode mode) {
+  if (failsafe_active) {
+    return "Failsafe";
+  }
+  if (lockout) {
+    return "Locked Out";
+  }
+  if (!connected) {
+    return "Not Connected";
+  }
+  if (windows_open && mode == FurnaceMode::Cool) {
+    return "Windows Open";
+  }
+
+  switch (state) {
+    case FurnaceStateCode::Idle:
+      return "Idle";
+    case FurnaceStateCode::HeatMode:
+      return "Heat mode";
+    case FurnaceStateCode::HeatOn:
+      return "Heat on";
+    case FurnaceStateCode::CoolMode:
+      return "Cool mode";
+    case FurnaceStateCode::CoolOn:
+      return "Cool on";
+    case FurnaceStateCode::FanOn:
+      return "Fan on";
+    case FurnaceStateCode::HeatWait:
+    case FurnaceStateCode::CoolWait:
+      return "Waiting for equipment";
+    case FurnaceStateCode::Error:
+    default:
+      return "Error";
+  }
+}
+```
+
+- [ ] **Step 5: Update the `status_text` caller in `thermostat_display_app.cpp`**
+
+In `src/thermostat/thermostat_display_app.cpp` `status_text` (around lines 60–67), replace the body:
+
+```cpp
+std::string ThermostatDisplayApp::status_text(uint32_t now_ms,
+                                              uint32_t connection_timeout_ms) const {
+  const bool connected = app_.controller_connected(now_ms, connection_timeout_ms);
+  const bool has_tel = app_.has_controller_telemetry();
+  const bool lockout = has_tel ? app_.controller_lockout() : false;
+  const bool windows_open = has_tel ? app_.controller_windows_open() : false;
+  const auto state =
+      has_tel ? app_.controller_state() : FurnaceStateCode::Error;
+  const FurnaceMode mode = app_.local_mode();
+  return furnace_state_text(state, connected, lockout, /*failsafe_active=*/false,
+                            windows_open, mode);
+}
+```
+
+Confirm that `app_.local_mode()` exists — it's the user's currently-selected mode on the display. If the method is named differently (e.g. `mode()` or `controller_mode()`), use that instead.
+
+Run: `grep -n "local_mode\|FurnaceMode " include/thermostat/thermostat_app.h`
+
+If `local_mode()` doesn't exist, use `app_.controller_mode()` if available, or whichever accessor returns the active `FurnaceMode`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pio run -e native-tests && .pio/build/native-tests/program`
+Expected: All new and existing tests pass.
+
+- [ ] **Step 7: Build display firmware**
+
+Run: `pio run -e esp32-furnace-thermostat`
+Expected: build succeeds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add include/thermostat/thermostat_ui_state.h src/thermostat/thermostat_ui_state.cpp \
+        src/thermostat/thermostat_display_app.cpp src/tests/test_thermostat_ui_state.cpp
+git commit -m "feat(display): show 'Windows Open' in status text when active mode is Cool"
+```
+
+---
+
+## Task 7: Simulator — toggle key and MQTT command for `windows_open`
+
+Adds parity with the lockout toggle so the sim can drive the new state.
+
+**Files:**
+- Modify: `src/sim/controller_preview.cpp`
+
+- [ ] **Step 1: Add MQTT command handler for `cmd/windows_open`**
+
+In `src/sim/controller_preview.cpp` around line 310, after the `cmd/lockout` handler:
+
+```cpp
+  if (topic == self_topic("cmd/lockout")) {
+    g_app->set_hvac_lockout(mqtt_payload::parse_bool(payload.c_str()));
+    publish_controller_extras();
+    return;
+  }
+```
+
+Add:
+
+```cpp
+  if (topic == self_topic("cmd/windows_open")) {
+    g_app->set_windows_open(mqtt_payload::parse_bool(payload.c_str()));
+    publish_controller_extras();
+    return;
+  }
+```
+
+- [ ] **Step 2: Add a keyboard shortcut to toggle `windows_open`**
+
+In `src/sim/controller_preview.cpp` around lines 827–830, after the lockout toggle:
+
+```cpp
+    case SDLK_l:
+      g_app->set_hvac_lockout(!g_app->runtime().hvac_lockout());
+      publish_controller_extras();
+      break;
+```
+
+Add:
+
+```cpp
+    case SDLK_o:
+      g_app->set_windows_open(!g_app->runtime().windows_open());
+      publish_controller_extras();
+      break;
+```
+
+- [ ] **Step 3: Add a status overlay line for windows_open**
+
+In `src/sim/controller_preview.cpp` around line 568, after the existing lockout overlay:
+
+```cpp
+  snprintf(buf, sizeof(buf), "Lockout: %s", g_app->runtime().hvac_lockout() ? "ACTIVE" : "OK");
+```
+
+Find the corresponding draw call and add a sibling overlay drawn below it:
+
+```cpp
+  snprintf(buf, sizeof(buf), "Windows: %s", g_app->runtime().windows_open() ? "OPEN" : "OK");
+  // ... mirror the existing draw_text call for the lockout line, offset y by one row;
+  //     use kColorRed if windows_open, kColorGreen otherwise.
+```
+
+Match the existing positioning and rendering API used for the lockout overlay; do not invent new helpers.
+
+- [ ] **Step 4: Build the sim**
+
+Run: `pio run -e sim-controller-preview` (or whichever sim env exists — check `platformio.ini`).
+
+Run: `grep -n "^\[env:" platformio.ini`
+Use the matching sim env name.
+
+Expected: sim build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sim/controller_preview.cpp
+git commit -m "feat(sim): toggle and MQTT command parity for windows_open"
+```
+
+---
+
+## Task 8: Full verification and final review
+
+- [ ] **Step 1: Run all native tests**
+
+Run: `pio run -e native-tests && .pio/build/native-tests/program`
+Expected: All tests pass; new windows_open tests are listed in output.
+
+- [ ] **Step 2: Build both firmwares**
+
+Run: `pio run -e esp32-furnace-controller`
+Run: `pio run -e esp32-furnace-thermostat`
+Expected: both succeed.
+
+- [ ] **Step 3: Manual smoke check (optional, requires hardware)**
+
+If hardware is available:
+1. Set HVAC mode to Off and wait 60s per the flashing runbook.
+2. Flash both firmwares.
+3. From an MQTT CLI: `mosquitto_pub -t "<base>/devices/<ctrl_mac>/cmd/windows_open" -m "1"`.
+4. Confirm `state/windows_open` is published as "1".
+5. Set mode to Cool, raise indoor temperature above setpoint → confirm cooling does NOT start.
+6. Confirm display status text reads "Windows Open".
+7. Publish `cmd/windows_open` "0" → cooling resumes after min-off elapses.
+8. With windows_open active, switch to Heat → display shows "Heat mode" (no "Windows Open" text).
+
+- [ ] **Step 4: Final commit if any cleanup needed, then push (or open PR per user direction)**
+
+This plan does not push or open a PR; the user will decide whether to merge directly or open a PR.
+
+---
+
+## Self-Review Summary
+
+- **Spec coverage:** All spec sections mapped — runtime suppression (Task 1), app/telemetry plumbing (Task 2), ESP-NOW (Task 3), MQTT command/state/discovery/status page (Task 4), display app field (Task 5), display status text gated to Cool mode (Task 6), sim parity (Task 7), verification (Task 8). The open item "free bit in ESP-NOW packet" is resolved in Task 3 by reusing the `lockout` byte's spare bits (no protocol bump). The open item "furnace_state_text signature" is resolved in Task 6 by adding `bool windows_open` and `FurnaceMode mode` parameters.
+- **Placeholders:** None.
+- **Type consistency:** `set_windows_open` / `windows_open()` used uniformly across runtime, app, and sim. `ThermostatSnapshot::windows_open`, `ControllerTelemetry::windows_open`, and `ThermostatControllerTelemetry::windows_open` are all `bool`. MQTT topic `cmd/windows_open` and state topic `state/windows_open` used uniformly.

--- a/docs/superpowers/specs/2026-05-12-windows-open-ac-disable-design.md
+++ b/docs/superpowers/specs/2026-05-12-windows-open-ac-disable-design.md
@@ -1,0 +1,145 @@
+# Windows Open A/C Disable — Design
+
+**Date:** 2026-05-12
+**Status:** Approved — ready for implementation plan
+**Scope:** Controller firmware, thermostat display firmware, sim
+
+## Summary
+
+Add a new boolean state, `windows_open`, owned by Home Assistant and pushed to the controller over MQTT. While the signal is active the controller suppresses cooling demand only — heat, fan, mode/setpoint changes, and all other HVAC behavior continue normally. The thermostat display surfaces a "Windows Open" message in the status line **only when the active mode is Cool**.
+
+## Motivation
+
+When a user opens windows/doors during cooling season, running the A/C is wasteful and uncomfortable. Home Assistant already aggregates door/window sensor state. This feature gives HA a clean, dedicated lever to disable cooling without forcing the user (or an automation) to toggle the whole HVAC mode off — which would also stop heating during shoulder seasons or unrelated cases.
+
+## Design Decisions
+
+| Question | Decision | Rationale |
+|---|---|---|
+| Source of signal | MQTT command from HA only | Mirrors existing `hvac_lockout` pattern; no controller hardware change. |
+| Behavior during active cooling | Honor min-run-time, then idle | Avoids short-cycling compressor on brief door openings. |
+| Scope of suppression | Cooling only | Per user request. Fan (circulate/always-on) and heat continue normally. |
+| Display priority | Only show "Windows Open" when active mode is Cool | When in Heat/Off, the windows-open state is irrelevant to the user's current intent. |
+| State persistence | None on controller | HA publishes the command as a retained MQTT topic; controller picks it up on reconnect. |
+| Furnace state code | No new code | Suppressed-cooling-Idle is still functionally Idle; flag rides separately on snapshot. |
+
+## Architecture
+
+### Data flow
+
+```
+HA windows/doors aggregation
+        │
+        │ MQTT: {base}/devices/{ctrl_mac}/cmd/windows_open  (retained)
+        ▼
+Controller (ESP32)
+  ControllerApp::set_windows_open(bool)
+        │
+        ▼
+  ControllerRuntime::windows_open_  ──► suppresses cool_call in apply_hvac_calls()
+        │
+        │ Published in retained state JSON, included in ESP-NOW snapshot
+        ▼
+Thermostat Display
+  parses windows_open into mirrored snapshot
+        │
+        ▼
+  furnace_state_text() returns "Windows Open" when mode==Cool and flag set
+```
+
+### Components changed
+
+**Shared (`include/`):**
+- `thermostat_types.h` — `ThermostatSnapshot` gains `bool windows_open = false`.
+- `espnow_cmd_word.h` — snapshot serializer gains one bit for `windows_open`. If no free bit exists in the current packed word, this becomes a protocol-version bump — both controller and display firmwares must be flashed in lockstep. Implementation plan must verify bit availability first.
+
+**Controller (`src/controller/`, `include/controller/`):**
+- `controller_runtime.h/.cpp`
+  - New field `bool windows_open_ = false`.
+  - New methods `void set_windows_open(bool)` and `bool windows_open() const`.
+  - `apply_hvac_calls(now, heat_call, cool_call)`: at function entry, force `cool_call = false` if `windows_open_` is true. Existing min-run-time logic in the `Cooling` branch handles graceful shutdown.
+  - `snapshot()` populates `s.windows_open`.
+  - State transitions audit-logged: `"windows_open: on/off [mqtt]"`.
+- `controller_app.h/.cpp` — thin pass-through `set_windows_open(bool)`.
+
+**Controller firmware (`src/esp32_controller_main.cpp`):**
+- Subscribe and handle new MQTT command topic `cmd/windows_open` (gated by `ha_allowed`, alongside `cmd/lockout`).
+- Add `"windows_open": true/false` to retained runtime-state JSON.
+- Add status-page HTML row "Windows Open".
+- Publish HA MQTT discovery for a `switch` entity (mirroring `hvac_lockout` discovery) so HA can both drive and observe the value.
+
+**Display (`src/thermostat/`, `include/thermostat/`):**
+- `thermostat_ui_state.h/.cpp` — `furnace_state_text(...)` gains parameter `bool windows_open` and parameter `FurnaceMode mode` (or accepts the full snapshot — see plan). Returns `"Windows Open"` when `mode == FurnaceMode::Cool && windows_open` and no higher-priority state applies.
+- MQTT subscriber on display parses `windows_open` from controller state JSON.
+- ESP-NOW receiver path stores the bit into the mirrored snapshot.
+
+**Sim (`src/sim/controller_preview.cpp`):**
+- Toggle button for `windows_open`.
+- Parse `cmd/windows_open` on the sim's MQTT bridge.
+- Status overlay shows windows-open status (parity with lockout).
+
+### Status text priority (display)
+
+Updated order in `furnace_state_text`:
+
+```
+1. Failsafe        → "Failsafe"
+2. Locked Out      → "Locked Out"
+3. Not Connected   → "Not Connected"
+4. mode==Cool && windows_open
+                   → "Windows Open"
+5. (existing state-code switch: Idle, HeatMode, HeatOn, CoolMode,
+    CoolOn, FanOn, HeatWait, CoolWait, Error)
+```
+
+If `windows_open` is true but the user is in Heat or Off mode, the status reads as it would today (no "Windows Open" text). If a compressor is still finishing its min-run-time after `windows_open` goes true, the user briefly sees `"Cool on"`. Once cooling idles, the text transitions to `"Windows Open"`.
+
+### Cooling suppression — exact semantics
+
+In `ControllerRuntime::apply_hvac_calls(now_ms, heat_call, cool_call)`:
+
+```cpp
+if (windows_open_) {
+  cool_call = false;
+}
+```
+
+This goes **after** the existing `failsafe_active_ || hvac_lockout_` early-return (so those still force full idle) and **before** the state machine switch. Effect:
+
+- **HvacState::Cooling**: existing `!cool_call && min_run_done` branch idles the compressor once min-run elapses. While min-run is unmet, cooling continues — by design.
+- **HvacState::Idle**: re-entry into Cooling requires `cool_call == true`, which it never will be while `windows_open_` is set.
+- **HvacState::Heating**: untouched.
+- Fan-circulate logic (later in tick) is untouched and continues to run.
+
+## Testing
+
+Native unit tests (`src/tests/test_controller_runtime.cpp`):
+1. `cool_call` is suppressed when `windows_open` is set; runtime stays in Idle.
+2. `heat_call` is unaffected when `windows_open` is set.
+3. Active Cooling honors min-run-time before idling on `windows_open=true`.
+4. Cannot re-enter Cooling while `windows_open=true`, even after min-off-time has elapsed.
+5. Fan-circulate continues to run while `windows_open=true` in Cool mode.
+6. Snapshot reflects `windows_open` correctly across set/clear.
+
+Display unit tests (`thermostat_ui_state`):
+1. `"Windows Open"` returned when `mode == Cool && windows_open == true` and no higher-priority state active.
+2. Higher-priority states (Failsafe, Locked Out, Not Connected) override.
+3. Heat or Off mode with `windows_open == true` returns normal mode/state text.
+
+Integration (manual / sim):
+- Toggle windows-open in sim while in Cool mode; observe display status flip and compressor idle after min-run.
+- HA discovery surfaces the new switch entity.
+
+## Out of Scope
+
+- Persistence of `windows_open` across controller reboot (HA's retained MQTT topic handles this).
+- Per-zone or multiple window-sensor handling (HA aggregates upstream).
+- Automatic mode switching (we never modify the user's mode selection).
+- Suppressing fan when windows are open.
+- Adding `windows_open` to the audit-log-only diagnostics; standard transition audit lines are sufficient.
+
+## Open Items for Implementation Plan
+
+1. Verify free bit in `espnow_cmd_word.h` packed snapshot word. If none, design the protocol-version bump and coordinated rollout (controller + display flashed together).
+2. Confirm exact `furnace_state_text` signature change — pass `bool windows_open` + `FurnaceMode mode` as additional params, or refactor the function to take a `ThermostatSnapshot` + connection bool. Latter is cleaner; affects all callers.
+3. HA discovery payload shape for `switch` entity (copy `hvac_lockout` discovery as template).

--- a/include/controller/controller_app.h
+++ b/include/controller/controller_app.h
@@ -16,6 +16,7 @@ struct ControllerTelemetry {
   uint8_t mode_code = 0;  // off=0, heat=1, cool=2
   uint8_t fan_code = 0;   // auto=0, on=1, circulate=2
   float setpoint_c = 0.0f;
+  bool windows_open = false;
 };
 
 class IControllerTransport {
@@ -39,6 +40,7 @@ class ControllerApp {
                                     const uint8_t *source_mac = nullptr);
   void on_thermostat_ack(uint16_t seq);
   void set_hvac_lockout(bool locked);
+  void set_windows_open(bool open);
   void reset_remote_command_sequence();
 
   // Weather state: controller stores latest weather for MQTT publishing

--- a/include/controller/controller_runtime.h
+++ b/include/controller/controller_runtime.h
@@ -50,6 +50,7 @@ class ControllerRuntime {
 
   void note_heartbeat(uint32_t now_ms);
   void set_hvac_lockout(bool locked_out);
+  void set_windows_open(bool open);
   void reset_remote_command_sequence();
 
   CommandApplyResult apply_remote_command(const CommandWord &cmd,
@@ -69,6 +70,7 @@ class ControllerRuntime {
 
   bool failsafe_active() const { return failsafe_active_; }
   bool hvac_lockout() const { return hvac_lockout_; }
+  bool windows_open() const { return windows_open_; }
   bool max_runtime_exceeded() const { return max_runtime_exceeded_; }
 
   bool heat_demand() const { return relay_.heat; }
@@ -113,6 +115,7 @@ class ControllerRuntime {
 
   bool hvac_lockout_ = false;
   bool failsafe_active_ = false;
+  bool windows_open_ = false;
   bool max_runtime_exceeded_ = false;
   bool spare_relay_4_ = false;
 

--- a/include/discovery_topics.h
+++ b/include/discovery_topics.h
@@ -12,10 +12,11 @@ struct DiscoveryEntity {
   const char *suffix;     // e.g. "_lockout", "" (for climate)
 };
 
-// Controller entities (22 total) — must match ctrl_publish_discovery()
+// Controller entities (23 total) — must match ctrl_publish_discovery()
 static constexpr DiscoveryEntity kControllerDiscoveryEntities[] = {
     {"climate", ""},
     {"switch", "_lockout"},
+    {"switch", "_windows_open"},
     {"sensor", "_filter_runtime"},
     {"sensor", "_furnace_state"},
     {"sensor", "_controller_firmware"},

--- a/include/thermostat/thermostat_app.h
+++ b/include/thermostat/thermostat_app.h
@@ -27,7 +27,8 @@ class ThermostatApp {
                                   FurnaceMode mode,
                                   FanMode fan,
                                   float setpoint_c,
-                                  uint32_t filter_runtime_seconds);
+                                  uint32_t filter_runtime_seconds,
+                                  bool windows_open);
 
   void set_local_mode(FurnaceMode mode, uint32_t now_ms);
   void set_local_fan_mode(FanMode mode, uint32_t now_ms);
@@ -54,6 +55,7 @@ class ThermostatApp {
   bool has_controller_telemetry() const { return has_controller_telemetry_; }
   FurnaceStateCode controller_state() const { return controller_state_; }
   bool controller_lockout() const { return controller_lockout_; }
+  bool controller_windows_open() const { return controller_windows_open_; }
   float controller_setpoint_c() const { return controller_setpoint_c_; }
   uint32_t controller_filter_runtime_seconds() const {
     return controller_filter_runtime_seconds_;
@@ -91,6 +93,7 @@ class ThermostatApp {
   bool has_controller_telemetry_ = false;
   FurnaceStateCode controller_state_ = FurnaceStateCode::Error;
   bool controller_lockout_ = false;
+  bool controller_windows_open_ = false;
   float controller_setpoint_c_ = 20.0f;
   uint32_t controller_filter_runtime_seconds_ = 0;
 

--- a/include/thermostat/thermostat_device_runtime.h
+++ b/include/thermostat/thermostat_device_runtime.h
@@ -30,7 +30,8 @@ class ThermostatDeviceRuntime {
                                   FurnaceMode mode,
                                   FanMode fan,
                                   float setpoint_c,
-                                  uint32_t filter_runtime_seconds);
+                                  uint32_t filter_runtime_seconds,
+                                  bool windows_open);
 
   void on_user_set_setpoint(float user_value, uint32_t now_ms);
   void on_user_set_setpoint_c(float setpoint_c, uint32_t now_ms);

--- a/include/thermostat/thermostat_display_app.h
+++ b/include/thermostat/thermostat_display_app.h
@@ -31,7 +31,8 @@ class ThermostatDisplayApp {
                                   FurnaceMode mode,
                                   FanMode fan,
                                   float setpoint_c,
-                                  uint32_t filter_runtime_seconds);
+                                  uint32_t filter_runtime_seconds,
+                                  bool windows_open);
 
   void on_user_set_setpoint(float user_value, uint32_t now_ms);
   void on_user_set_setpoint_c(float setpoint_c, uint32_t now_ms);

--- a/include/thermostat/thermostat_ui_state.h
+++ b/include/thermostat/thermostat_ui_state.h
@@ -9,7 +9,9 @@ namespace thermostat {
 std::string furnace_state_text(FurnaceStateCode state,
                                bool connected,
                                bool lockout,
-                               bool failsafe_active);
+                               bool failsafe_active,
+                               bool windows_open,
+                               FurnaceMode mode);
 
 std::string furnace_mode_text(FurnaceMode mode);
 std::string fan_mode_text(FanMode mode);

--- a/include/thermostat/transport/espnow_thermostat_transport.h
+++ b/include/thermostat/transport/espnow_thermostat_transport.h
@@ -18,6 +18,7 @@ struct ThermostatControllerTelemetry {
   uint8_t fan_code = 0;
   float setpoint_c = 0.0f;
   uint32_t filter_runtime_seconds = 0;
+  bool windows_open = false;
 };
 
 struct EspNowThermostatConfig {

--- a/include/thermostat_types.h
+++ b/include/thermostat_types.h
@@ -41,4 +41,5 @@ struct ThermostatSnapshot {
   RelayDemand relay{};
   bool hvac_lockout = false;
   bool failsafe_active = false;
+  bool windows_open = false;
 };

--- a/src/controller/controller_app.cpp
+++ b/src/controller/controller_app.cpp
@@ -41,7 +41,8 @@ bool ControllerApp::telemetry_payload_changed(const ControllerTelemetry &next) c
   return next.state != last_published_.state ||
          next.filter_runtime_hours != last_published_.filter_runtime_hours ||
          next.lockout != last_published_.lockout || next.mode_code != last_published_.mode_code ||
-         next.fan_code != last_published_.fan_code || next.setpoint_c != last_published_.setpoint_c;
+         next.fan_code != last_published_.fan_code || next.setpoint_c != last_published_.setpoint_c ||
+         next.windows_open != last_published_.windows_open;
 }
 
 void ControllerApp::on_heartbeat(uint32_t now_ms) {
@@ -72,6 +73,11 @@ void ControllerApp::on_thermostat_ack(uint16_t seq) {
 
 void ControllerApp::set_hvac_lockout(bool locked) {
   runtime_.set_hvac_lockout(locked);
+  publish();
+}
+
+void ControllerApp::set_windows_open(bool open) {
+  runtime_.set_windows_open(open);
   publish();
 }
 
@@ -207,6 +213,7 @@ void ControllerApp::publish() {
   t.mode_code = mode_to_code(runtime_.mode());
   t.fan_code = fan_to_code(runtime_.fan_mode());
   t.setpoint_c = runtime_.target_temperature_c();
+  t.windows_open = runtime_.windows_open();
 
   if (!telemetry_payload_changed(t)) {
     return;  // Nothing changed — skip the send

--- a/src/controller/controller_runtime.cpp
+++ b/src/controller/controller_runtime.cpp
@@ -60,6 +60,13 @@ void ControllerRuntime::set_hvac_lockout(bool locked_out) {
   }
 }
 
+void ControllerRuntime::set_windows_open(bool open) {
+  if (open != windows_open_) {
+    audit("windows_open: %s [internal]", open ? "on" : "off");
+  }
+  windows_open_ = open;
+}
+
 void ControllerRuntime::reset_remote_command_sequence() {
   last_seq_default_ = 0;
   for (int i = 0; i < kMaxCommandSources; ++i) {
@@ -212,6 +219,7 @@ ThermostatSnapshot ControllerRuntime::snapshot() const {
   s.relay = relay_;
   s.hvac_lockout = hvac_lockout_;
   s.failsafe_active = failsafe_active_;
+  s.windows_open = windows_open_;
   return s;
 }
 
@@ -251,6 +259,10 @@ void ControllerRuntime::apply_hvac_calls(uint32_t now_ms, bool heat_call, bool c
     relay_.fan = false;
     equipment_delay_ = false;
     return;
+  }
+
+  if (windows_open_) {
+    cool_call = false;
   }
 
   switch (hvac_state_) {

--- a/src/controller/transport/espnow_controller_transport.cpp
+++ b/src/controller/transport/espnow_controller_transport.cpp
@@ -150,7 +150,8 @@ void EspNowControllerTransport::publish_telemetry(
   pkt.header.version = kEspNowProtocolVersion;
   pkt.seq = telemetry.seq;
   pkt.state = static_cast<uint8_t>(telemetry.state);
-  pkt.lockout = telemetry.lockout ? 1 : 0;
+  pkt.lockout = static_cast<uint8_t>((telemetry.lockout ? 0x01 : 0x00) |
+                                   (telemetry.windows_open ? 0x02 : 0x00));
   pkt.mode = telemetry.mode_code;
   pkt.fan = telemetry.fan_code;
 

--- a/src/esp32_controller_main.cpp
+++ b/src/esp32_controller_main.cpp
@@ -806,6 +806,7 @@ void ctrl_publish_discovery() {
   const String dev_id = g_cfg_base_topic + "_" + g_cfg_device_mac_compact + "_controller";
   const String dp = g_cfg_ctrl_discovery_prefix + "/";
   const String switch_topic = dp + "switch/" + dev_id + "_lockout/config";
+  const String windows_open_topic = dp + "switch/" + dev_id + "_windows_open/config";
   const String filter_topic = dp + "sensor/" + dev_id + "_filter_runtime/config";
   const String state_topic = dp + "sensor/" + dev_id + "_furnace_state/config";
   const String fw_topic = dp + "sensor/" + dev_id + "_controller_firmware/config";
@@ -868,6 +869,14 @@ void ctrl_publish_discovery() {
            "\"dev\":{\"ids\":[\"%s\"]}}",
            dev_id.c_str(), base.c_str(), base.c_str(), dev_id.c_str());
   g_ctrl_mqtt.publish(switch_topic.c_str(), payload, true);
+
+  snprintf(payload, sizeof(payload),
+           "{\"name\":\"Windows Open\",\"uniq_id\":\"%s_windows_open\","
+           "\"cmd_t\":\"%s/cmd/windows_open\","
+           "\"stat_t\":\"%s/state/windows_open\",\"pl_on\":\"1\",\"pl_off\":\"0\","
+           "\"dev\":{\"ids\":[\"%s\"]}}",
+           dev_id.c_str(), base.c_str(), base.c_str(), dev_id.c_str());
+  g_ctrl_mqtt.publish(windows_open_topic.c_str(), payload, true);
 
   snprintf(payload, sizeof(payload),
            "{\"name\":\"Filter Runtime\",\"uniq_id\":\"%s_filter_runtime\","
@@ -1205,6 +1214,7 @@ void ctrl_web_handle_status_get() {
     "\"fan_mode\":\"%s\","
     "\"target_temp_c\":%.1f,"
     "\"hvac_lockout\":%s,"
+    "\"windows_open\":%s,"
     "\"failsafe_active\":%s,"
     "\"espnow_connected\":%s,"
     "\"heartbeat_last_seen_ms\":%lu,"
@@ -1235,6 +1245,7 @@ void ctrl_web_handle_status_get() {
     mqtt_payload::fan_to_str(rt.fan_mode()),
     static_cast<double>(rt.target_temperature_c()),
     rt.hvac_lockout() ? "true" : "false",
+    rt.windows_open() ? "true" : "false",
     rt.failsafe_active() ? "true" : "false",
     (rt.heartbeat_last_seen_ms() > 0 && (now - rt.heartbeat_last_seen_ms()) < 30000UL) ? "true" : "false",
     static_cast<unsigned long>(rt.heartbeat_last_seen_ms()),
@@ -1312,6 +1323,7 @@ void ctrl_web_handle_root() {
   status_item(html, "Mode", "mode");
   status_item(html, "Fan", "fan_mode");
   status_item(html, "HVAC Lockout", "hvac_lockout");
+  status_item(html, "Windows Open", "windows_open");
   status_item(html, "Failsafe", "failsafe_active");
   status_item(html, "Filter Hours", "filter_runtime_hours");
   status_item(html, "Heat Relay", "relay_heat");
@@ -1584,6 +1596,8 @@ void ctrl_publish_runtime_state() {
   char buf[32];
   g_ctrl_mqtt.publish(self_topic_for("state/availability").c_str(), "online", true);
   g_ctrl_mqtt.publish(self_topic_for("state/lockout").c_str(), lockout ? "1" : "0", true);
+  g_ctrl_mqtt.publish(self_topic_for("state/windows_open").c_str(),
+                      rt.windows_open() ? "1" : "0", true);
   g_ctrl_mqtt.publish(self_topic_for("state/mode").c_str(), mode, true);
   g_ctrl_mqtt.publish(self_topic_for("state/fan_mode").c_str(), fan, true);
   {
@@ -1873,6 +1887,7 @@ void ctrl_mqtt_on_message(char *topic, uint8_t *payload, unsigned int length) {
   // Block lockout and HVAC commands when HA is not allowed
   if (!ha_allowed) {
     if (topic_str == self_topic_for("cmd/lockout") ||
+        topic_str == self_topic_for("cmd/windows_open") ||
         topic_str == self_topic_for("cmd/mode") ||
         topic_str == self_topic_for("cmd/fan_mode") ||
         topic_str == self_topic_for("cmd/target_temp_c") ||
@@ -1887,6 +1902,14 @@ void ctrl_mqtt_on_message(char *topic, uint8_t *payload, unsigned int length) {
     const bool new_lockout = mqtt_payload::parse_bool(value);
     ctrl_audit("lockout: %s [mqtt]", new_lockout ? "on" : "off");
     g_controller->app().set_hvac_lockout(new_lockout);
+    ctrl_publish_runtime_state();
+    return;
+  }
+
+  if (topic_str == self_topic_for("cmd/windows_open")) {
+    const bool new_value = mqtt_payload::parse_bool(value);
+    ctrl_audit("windows_open: %s [mqtt]", new_value ? "on" : "off");
+    g_controller->app().set_windows_open(new_value);
     ctrl_publish_runtime_state();
     return;
   }
@@ -2034,6 +2057,7 @@ void ctrl_ensure_mqtt_connected(uint32_t now_ms) {
 
   const bool subs_ok =
       g_ctrl_mqtt.subscribe(self_topic_for("cmd/lockout").c_str()) &&
+      g_ctrl_mqtt.subscribe(self_topic_for("cmd/windows_open").c_str()) &&
       g_ctrl_mqtt.subscribe(self_topic_for("cmd/mode").c_str()) &&
       g_ctrl_mqtt.subscribe(self_topic_for("cmd/fan_mode").c_str()) &&
       g_ctrl_mqtt.subscribe(self_topic_for("cmd/target_temp_c").c_str()) &&

--- a/src/sim/controller_preview.cpp
+++ b/src/sim/controller_preview.cpp
@@ -313,6 +313,12 @@ void on_mqtt_message(const std::string &topic, const std::string &payload) {
     return;
   }
 
+  if (topic == self_topic("cmd/windows_open")) {
+    g_app->set_windows_open(mqtt_payload::parse_bool(payload.c_str()));
+    publish_controller_extras();
+    return;
+  }
+
   if (topic == self_topic("cmd/mode")) {
     FurnaceMode mode = mqtt_payload::str_to_mode(payload.c_str());
 
@@ -568,6 +574,11 @@ void draw_diagnostics_panel(int x, int y, int w, int h) {
   snprintf(buf, sizeof(buf), "Lockout: %s", g_app->runtime().hvac_lockout() ? "ACTIVE" : "OK");
   draw_text(g_font_small, x + 10, ly, buf,
             g_app->runtime().hvac_lockout() ? kColorRed : kColorGreen);
+  ly += line_height;
+
+  snprintf(buf, sizeof(buf), "Windows: %s", g_app->runtime().windows_open() ? "OPEN" : "OK");
+  draw_text(g_font_small, x + 10, ly, buf,
+            g_app->runtime().windows_open() ? kColorRed : kColorGreen);
   ly += line_height;
 
   // Filter runtime
@@ -826,6 +837,11 @@ void handle_keypress(SDL_Keycode key) {
 
     case SDLK_l:
       g_app->set_hvac_lockout(!g_app->runtime().hvac_lockout());
+      publish_controller_extras();
+      break;
+
+    case SDLK_i:
+      g_app->set_windows_open(!g_app->runtime().windows_open());
       publish_controller_extras();
       break;
 

--- a/src/tests/test_controller_runtime.cpp
+++ b/src/tests/test_controller_runtime.cpp
@@ -741,4 +741,88 @@ TEST_CASE(controller_runtime_windows_open_honors_cool_min_run_time) {
   rt.tick(t3);
   ASSERT_TRUE(!rt.cool_demand());
 }
+
+TEST_CASE(controller_runtime_windows_open_blocks_cooling_re_entry_after_min_off) {
+  // After cooling idles, windows_open must prevent re-entry regardless of elapsed time.
+  thermostat::ControllerConfig cfg;
+  cfg.failsafe_timeout_ms = 1000000;
+  cfg.min_idle_time_ms = 0;
+  cfg.min_cooling_off_time_ms = 0;  // zero so only windows_open gates re-entry
+  cfg.min_cooling_run_time_ms = 0;
+  thermostat::ControllerRuntime rt(cfg);
+  rt.note_heartbeat(1);
+
+  CommandWord cmd;
+  cmd.mode = FurnaceMode::Cool;
+  cmd.seq = 1;
+  ASSERT_TRUE(rt.apply_remote_command(cmd).accepted);
+
+  // Start cooling
+  thermostat::ControllerTickInput t1;
+  t1.now_ms = 1000;
+  t1.cool_call = true;
+  t1.has_indoor_temp = true;
+  rt.tick(t1);
+  ASSERT_TRUE(rt.cool_demand());
+
+  // Set windows open — cooling stops on the next tick
+  rt.set_windows_open(true);
+  thermostat::ControllerTickInput t2;
+  t2.now_ms = 2000;
+  t2.cool_call = false;
+  t2.has_indoor_temp = true;
+  rt.tick(t2);
+  ASSERT_TRUE(!rt.cool_demand());
+
+  // Plenty of time has passed (min-off-time is 0), but windows are still open
+  // — re-entry must be refused
+  thermostat::ControllerTickInput t3;
+  t3.now_ms = 999000;
+  t3.cool_call = true;
+  t3.has_indoor_temp = true;
+  rt.tick(t3);
+  ASSERT_TRUE(rt.windows_open());
+  ASSERT_TRUE(!rt.cool_demand());
+}
+
+TEST_CASE(controller_runtime_windows_open_fan_circulate_continues_in_cool_mode) {
+  // Fan-circulate must still trigger on schedule even when windows_open=true
+  // in Cool mode (windows_open only suppresses the compressor, not the fan).
+  thermostat::ControllerConfig cfg;
+  cfg.fan_circulate_period_min = 5;
+  cfg.fan_circulate_duration_min = 2;
+  cfg.min_idle_time_ms = 0;
+  cfg.min_cooling_off_time_ms = 0;
+  cfg.min_cooling_run_time_ms = 0;
+  thermostat::ControllerRuntime rt(cfg);
+
+  // Set Cool mode with Circulate fan
+  CommandWord cmd;
+  cmd.mode = FurnaceMode::Cool;
+  cmd.fan = FanMode::Circulate;
+  cmd.seq = 1;
+  ASSERT_TRUE(rt.apply_remote_command(cmd).accepted);
+
+  rt.set_windows_open(true);
+  rt.note_heartbeat(1);
+
+  // First tick — circulate period not reached yet
+  thermostat::ControllerTickInput t1;
+  t1.now_ms = 1000;
+  t1.cool_call = false;  // no cool demand (windows open)
+  t1.has_indoor_temp = true;
+  rt.tick(t1);
+
+  // Advance past circulate period (5 min = 300 s, period starts from first tick)
+  thermostat::ControllerTickInput t2;
+  t2.now_ms = 61000;  // matches the existing circulate test timing
+  t2.cool_call = false;
+  t2.has_indoor_temp = true;
+  rt.tick(t2);
+
+  // Fan should be circulating despite windows_open and despite no cool_demand
+  ASSERT_TRUE(rt.fan_demand());
+  // Cool demand must remain suppressed
+  ASSERT_TRUE(!rt.cool_demand());
+}
 #endif

--- a/src/tests/test_controller_runtime.cpp
+++ b/src/tests/test_controller_runtime.cpp
@@ -639,4 +639,106 @@ TEST_CASE(controller_runtime_off_mode_does_not_overwrite_setpoints) {
   ASSERT_TRUE(rt.heat_setpoint_c() == 21.5f);
   ASSERT_TRUE(rt.cool_setpoint_c() == 24.0f);
 }
+
+TEST_CASE(controller_runtime_windows_open_suppresses_cooling) {
+  thermostat::ControllerConfig cfg;
+  cfg.failsafe_timeout_ms = 1000000;
+  cfg.min_idle_time_ms = 0;
+  cfg.min_cooling_off_time_ms = 0;
+  cfg.min_cooling_run_time_ms = 0;
+  thermostat::ControllerRuntime rt(cfg);
+  rt.note_heartbeat(1);
+
+  CommandWord cmd;
+  cmd.mode = FurnaceMode::Cool;
+  cmd.seq = 1;
+  ASSERT_TRUE(rt.apply_remote_command(cmd).accepted);
+
+  thermostat::ControllerTickInput t1;
+  t1.now_ms = 1000;
+  t1.cool_call = true;
+  t1.has_indoor_temp = true;
+  rt.tick(t1);
+  ASSERT_TRUE(rt.cool_demand());
+
+  ASSERT_TRUE(!rt.snapshot().windows_open);
+
+  rt.set_windows_open(true);
+  thermostat::ControllerTickInput t2;
+  t2.now_ms = 2000;
+  t2.cool_call = true;
+  t2.has_indoor_temp = true;
+  rt.tick(t2);
+  ASSERT_TRUE(rt.windows_open());
+  ASSERT_TRUE(rt.snapshot().windows_open);
+  ASSERT_TRUE(!rt.cool_demand());
+
+  rt.set_windows_open(false);
+  thermostat::ControllerTickInput t3;
+  t3.now_ms = 3000;
+  t3.cool_call = true;
+  t3.has_indoor_temp = true;
+  rt.tick(t3);
+  ASSERT_TRUE(rt.cool_demand());
+}
+
+TEST_CASE(controller_runtime_windows_open_does_not_block_heat) {
+  thermostat::ControllerConfig cfg;
+  cfg.failsafe_timeout_ms = 1000000;
+  cfg.min_idle_time_ms = 0;
+  cfg.min_heating_off_time_ms = 0;
+  cfg.min_heating_run_time_ms = 0;
+  thermostat::ControllerRuntime rt(cfg);
+  rt.note_heartbeat(1);
+
+  CommandWord cmd;
+  cmd.mode = FurnaceMode::Heat;
+  cmd.seq = 1;
+  ASSERT_TRUE(rt.apply_remote_command(cmd).accepted);
+
+  rt.set_windows_open(true);
+  thermostat::ControllerTickInput t1;
+  t1.now_ms = 1000;
+  t1.heat_call = true;
+  t1.has_indoor_temp = true;
+  rt.tick(t1);
+  ASSERT_TRUE(rt.heat_demand());
+}
+
+TEST_CASE(controller_runtime_windows_open_honors_cool_min_run_time) {
+  thermostat::ControllerConfig cfg;
+  cfg.failsafe_timeout_ms = 1000000;
+  cfg.min_idle_time_ms = 0;
+  cfg.min_cooling_off_time_ms = 0;
+  cfg.min_cooling_run_time_ms = 60000;
+  thermostat::ControllerRuntime rt(cfg);
+  rt.note_heartbeat(1);
+
+  CommandWord cmd;
+  cmd.mode = FurnaceMode::Cool;
+  cmd.seq = 1;
+  ASSERT_TRUE(rt.apply_remote_command(cmd).accepted);
+
+  thermostat::ControllerTickInput t1;
+  t1.now_ms = 1000;
+  t1.cool_call = true;
+  t1.has_indoor_temp = true;
+  rt.tick(t1);
+  ASSERT_TRUE(rt.cool_demand());
+
+  rt.set_windows_open(true);
+  thermostat::ControllerTickInput t2;
+  t2.now_ms = 30000;
+  t2.cool_call = true;
+  t2.has_indoor_temp = true;
+  rt.tick(t2);
+  ASSERT_TRUE(rt.cool_demand());
+
+  thermostat::ControllerTickInput t3;
+  t3.now_ms = 70000;
+  t3.cool_call = true;
+  t3.has_indoor_temp = true;
+  rt.tick(t3);
+  ASSERT_TRUE(!rt.cool_demand());
+}
 #endif

--- a/src/tests/test_device_registry.cpp
+++ b/src/tests/test_device_registry.cpp
@@ -120,7 +120,7 @@ TEST_CASE(mac_strip_colons_handles_null) {
 // ── discovery_topics.h: entity counts ──
 
 TEST_CASE(discovery_controller_entity_count) {
-  ASSERT_EQ(kControllerDiscoveryCount, static_cast<size_t>(22));
+  ASSERT_EQ(kControllerDiscoveryCount, static_cast<size_t>(23));
 }
 
 TEST_CASE(discovery_display_entity_count) {

--- a/src/tests/test_display_model.cpp
+++ b/src/tests/test_display_model.cpp
@@ -36,9 +36,11 @@ TEST_CASE(display_model_indoor_temperature_includes_degree_symbol) {
 
 TEST_CASE(ui_state_text_mapping) {
   ASSERT_TRUE(thermostat::furnace_state_text(FurnaceStateCode::Idle, true,
-                                             false, false) == "Idle");
+                                             false, false, false,
+                                             FurnaceMode::Off) == "Idle");
   ASSERT_TRUE(thermostat::furnace_state_text(FurnaceStateCode::Idle, false,
-                                             false, false) == "Not Connected");
+                                             false, false, false,
+                                             FurnaceMode::Off) == "Not Connected");
   ASSERT_TRUE(thermostat::furnace_mode_text(FurnaceMode::Cool) == "Cool");
   ASSERT_TRUE(thermostat::fan_mode_text(FanMode::Circulate) == "Circulate");
 }

--- a/src/tests/test_mqtt_payload.cpp
+++ b/src/tests/test_mqtt_payload.cpp
@@ -1,0 +1,141 @@
+#if defined(THERMOSTAT_RUN_TESTS)
+#include "mqtt_payload.h"
+#include "test_harness.h"
+
+// --- mode_to_str / str_to_mode ---
+
+TEST_CASE(mqtt_payload_mode_to_str_all_modes) {
+  ASSERT_STR_EQ(mqtt_payload::mode_to_str(FurnaceMode::Off), "off");
+  ASSERT_STR_EQ(mqtt_payload::mode_to_str(FurnaceMode::Heat), "heat");
+  ASSERT_STR_EQ(mqtt_payload::mode_to_str(FurnaceMode::Cool), "cool");
+}
+
+TEST_CASE(mqtt_payload_mode_to_str_unknown_falls_back_to_off) {
+  // Any unmapped enum value must degrade gracefully — controller must never
+  // surface an unknown mode string on MQTT.
+  ASSERT_STR_EQ(mqtt_payload::mode_to_str(static_cast<FurnaceMode>(99)), "off");
+}
+
+TEST_CASE(mqtt_payload_str_to_mode_known_values) {
+  ASSERT_TRUE(mqtt_payload::str_to_mode("heat") == FurnaceMode::Heat);
+  ASSERT_TRUE(mqtt_payload::str_to_mode("cool") == FurnaceMode::Cool);
+  ASSERT_TRUE(mqtt_payload::str_to_mode("off") == FurnaceMode::Off);
+}
+
+TEST_CASE(mqtt_payload_str_to_mode_is_case_sensitive) {
+  // HA sends lowercase. If this ever flips to case-insensitive we want to
+  // notice (downstream code assumes the canonical form).
+  ASSERT_TRUE(mqtt_payload::str_to_mode("Heat") == FurnaceMode::Off);
+  ASSERT_TRUE(mqtt_payload::str_to_mode("HEAT") == FurnaceMode::Off);
+}
+
+TEST_CASE(mqtt_payload_str_to_mode_unknown_falls_back_to_off) {
+  ASSERT_TRUE(mqtt_payload::str_to_mode("") == FurnaceMode::Off);
+  ASSERT_TRUE(mqtt_payload::str_to_mode("auto") == FurnaceMode::Off);
+  ASSERT_TRUE(mqtt_payload::str_to_mode("heat_cool") == FurnaceMode::Off);
+}
+
+// --- fan_to_str / str_to_fan ---
+
+TEST_CASE(mqtt_payload_fan_to_str_all_modes) {
+  ASSERT_STR_EQ(mqtt_payload::fan_to_str(FanMode::Automatic), "auto");
+  ASSERT_STR_EQ(mqtt_payload::fan_to_str(FanMode::AlwaysOn), "on");
+  ASSERT_STR_EQ(mqtt_payload::fan_to_str(FanMode::Circulate), "circulate");
+}
+
+TEST_CASE(mqtt_payload_fan_to_str_unknown_falls_back_to_auto) {
+  ASSERT_STR_EQ(mqtt_payload::fan_to_str(static_cast<FanMode>(99)), "auto");
+}
+
+TEST_CASE(mqtt_payload_str_to_fan_known_values) {
+  ASSERT_TRUE(mqtt_payload::str_to_fan("on") == FanMode::AlwaysOn);
+  ASSERT_TRUE(mqtt_payload::str_to_fan("circulate") == FanMode::Circulate);
+  ASSERT_TRUE(mqtt_payload::str_to_fan("auto") == FanMode::Automatic);
+}
+
+TEST_CASE(mqtt_payload_str_to_fan_always_on_alias) {
+  // "always on" is accepted as a synonym for "on". Pin this so we don't
+  // accidentally drop the alias and break older HA configs.
+  ASSERT_TRUE(mqtt_payload::str_to_fan("always on") == FanMode::AlwaysOn);
+}
+
+TEST_CASE(mqtt_payload_str_to_fan_unknown_falls_back_to_auto) {
+  ASSERT_TRUE(mqtt_payload::str_to_fan("") == FanMode::Automatic);
+  ASSERT_TRUE(mqtt_payload::str_to_fan("off") == FanMode::Automatic);
+  ASSERT_TRUE(mqtt_payload::str_to_fan("ON") == FanMode::Automatic);
+}
+
+// --- furnace_state_to_str / str_to_furnace_state ---
+
+TEST_CASE(mqtt_payload_furnace_state_to_str_all_states) {
+  ASSERT_STR_EQ(mqtt_payload::furnace_state_to_str(FurnaceStateCode::Idle), "Idle");
+  ASSERT_STR_EQ(mqtt_payload::furnace_state_to_str(FurnaceStateCode::HeatMode), "Heat Standby");
+  ASSERT_STR_EQ(mqtt_payload::furnace_state_to_str(FurnaceStateCode::HeatOn), "Heating");
+  ASSERT_STR_EQ(mqtt_payload::furnace_state_to_str(FurnaceStateCode::CoolMode), "Cool Standby");
+  ASSERT_STR_EQ(mqtt_payload::furnace_state_to_str(FurnaceStateCode::CoolOn), "Cooling");
+  ASSERT_STR_EQ(mqtt_payload::furnace_state_to_str(FurnaceStateCode::FanOn), "Fan Running");
+  ASSERT_STR_EQ(mqtt_payload::furnace_state_to_str(FurnaceStateCode::Error), "Error");
+  ASSERT_STR_EQ(mqtt_payload::furnace_state_to_str(FurnaceStateCode::HeatWait), "Heat Wait");
+  ASSERT_STR_EQ(mqtt_payload::furnace_state_to_str(FurnaceStateCode::CoolWait), "Cool Wait");
+}
+
+TEST_CASE(mqtt_payload_furnace_state_to_str_unknown) {
+  ASSERT_STR_EQ(mqtt_payload::furnace_state_to_str(static_cast<FurnaceStateCode>(99)),
+                "Unknown");
+}
+
+TEST_CASE(mqtt_payload_str_to_furnace_state_roundtrip) {
+  const FurnaceStateCode kStates[] = {
+      FurnaceStateCode::Idle,      FurnaceStateCode::HeatMode,
+      FurnaceStateCode::HeatOn,    FurnaceStateCode::CoolMode,
+      FurnaceStateCode::CoolOn,    FurnaceStateCode::FanOn,
+      FurnaceStateCode::HeatWait,  FurnaceStateCode::CoolWait,
+  };
+  for (FurnaceStateCode s : kStates) {
+    const char *text = mqtt_payload::furnace_state_to_str(s);
+    ASSERT_TRUE(mqtt_payload::str_to_furnace_state(text) == s);
+  }
+}
+
+TEST_CASE(mqtt_payload_str_to_furnace_state_unknown_returns_error) {
+  // Any string we don't recognize must map to Error so a corrupted retained
+  // message can't silently look like Idle.
+  ASSERT_TRUE(mqtt_payload::str_to_furnace_state("") == FurnaceStateCode::Error);
+  ASSERT_TRUE(mqtt_payload::str_to_furnace_state("idle") == FurnaceStateCode::Error);
+  ASSERT_TRUE(mqtt_payload::str_to_furnace_state("Standby") == FurnaceStateCode::Error);
+}
+
+// --- parse_bool ---
+
+TEST_CASE(mqtt_payload_parse_bool_truthy_values) {
+  ASSERT_TRUE(mqtt_payload::parse_bool("1"));
+  ASSERT_TRUE(mqtt_payload::parse_bool("true"));
+  ASSERT_TRUE(mqtt_payload::parse_bool("on"));
+}
+
+TEST_CASE(mqtt_payload_parse_bool_falsy_values) {
+  ASSERT_TRUE(!mqtt_payload::parse_bool("0"));
+  ASSERT_TRUE(!mqtt_payload::parse_bool("false"));
+  ASSERT_TRUE(!mqtt_payload::parse_bool("off"));
+  ASSERT_TRUE(!mqtt_payload::parse_bool(""));
+}
+
+TEST_CASE(mqtt_payload_parse_bool_handles_nullptr) {
+  // Some callers (e.g. retained-message clears) pass nullptr; must not crash.
+  ASSERT_TRUE(!mqtt_payload::parse_bool(nullptr));
+}
+
+TEST_CASE(mqtt_payload_parse_bool_is_case_sensitive) {
+  // Pin existing behavior: only lowercase canonical forms are truthy.
+  ASSERT_TRUE(!mqtt_payload::parse_bool("True"));
+  ASSERT_TRUE(!mqtt_payload::parse_bool("ON"));
+  ASSERT_TRUE(!mqtt_payload::parse_bool("YES"));
+}
+
+TEST_CASE(mqtt_payload_parse_bool_rejects_unknown) {
+  ASSERT_TRUE(!mqtt_payload::parse_bool("2"));
+  ASSERT_TRUE(!mqtt_payload::parse_bool("enabled"));
+  ASSERT_TRUE(!mqtt_payload::parse_bool(" on"));
+}
+
+#endif

--- a/src/tests/test_thermostat_app.cpp
+++ b/src/tests/test_thermostat_app.cpp
@@ -132,7 +132,7 @@ TEST_CASE(thermostat_app_controller_state_update_sets_fields) {
   // Apply MQTT-sourced controller state
   app.on_controller_state_update(
       1000, FurnaceStateCode::HeatOn, true,
-      FurnaceMode::Heat, FanMode::AlwaysOn, 23.5f, 7200);
+      FurnaceMode::Heat, FanMode::AlwaysOn, 23.5f, 7200, false);
 
   ASSERT_TRUE(app.has_controller_telemetry());
   ASSERT_TRUE(app.controller_connected(1000, 30000));
@@ -163,7 +163,7 @@ TEST_CASE(thermostat_app_controller_state_update_respects_debounce) {
   // Controller state update within debounce window (default 5000ms)
   app.on_controller_state_update(
       3000, FurnaceStateCode::HeatOn, false,
-      FurnaceMode::Heat, FanMode::Automatic, 25.0f, 0);
+      FurnaceMode::Heat, FanMode::Automatic, 25.0f, 0, false);
 
   // Controller fields should update
   ASSERT_TRUE(app.has_controller_telemetry());
@@ -177,7 +177,7 @@ TEST_CASE(thermostat_app_controller_state_update_respects_debounce) {
   // After debounce expires, should sync
   app.on_controller_state_update(
       7000, FurnaceStateCode::Idle, false,
-      FurnaceMode::Off, FanMode::Circulate, 20.0f, 3600);
+      FurnaceMode::Off, FanMode::Circulate, 20.0f, 3600, false);
 
   ASSERT_EQ(static_cast<int>(app.local_mode()),
             static_cast<int>(FurnaceMode::Off));

--- a/src/tests/test_thermostat_display_app.cpp
+++ b/src/tests/test_thermostat_display_app.cpp
@@ -76,7 +76,7 @@ TEST_CASE(thermostat_display_app_controller_state_update_pass_through) {
 
   display.on_controller_state_update(
       1000, FurnaceStateCode::CoolOn, false,
-      FurnaceMode::Cool, FanMode::Circulate, 24.0f, 3600);
+      FurnaceMode::Cool, FanMode::Circulate, 24.0f, 3600, false);
 
   // Verify state propagated through to app
   ASSERT_TRUE(app.has_controller_telemetry());

--- a/src/tests/test_thermostat_state.cpp
+++ b/src/tests/test_thermostat_state.cpp
@@ -1,0 +1,137 @@
+#if defined(THERMOSTAT_RUN_TESTS)
+#include "thermostat/thermostat_state.h"
+#include "test_harness.h"
+
+namespace {
+
+ThermostatSnapshot make_snapshot(FurnaceMode mode) {
+  ThermostatSnapshot s;
+  s.mode = mode;
+  return s;
+}
+
+}  // namespace
+
+// --- compute_furnace_state: relay precedence ---
+
+TEST_CASE(thermostat_state_heat_relay_reports_heat_on) {
+  ThermostatSnapshot s = make_snapshot(FurnaceMode::Heat);
+  s.relay.heat = true;
+  ASSERT_TRUE(thermostat::compute_furnace_state(s) == FurnaceStateCode::HeatOn);
+}
+
+TEST_CASE(thermostat_state_cool_relay_reports_cool_on) {
+  ThermostatSnapshot s = make_snapshot(FurnaceMode::Cool);
+  s.relay.cool = true;
+  ASSERT_TRUE(thermostat::compute_furnace_state(s) == FurnaceStateCode::CoolOn);
+}
+
+TEST_CASE(thermostat_state_fan_relay_reports_fan_on) {
+  ThermostatSnapshot s = make_snapshot(FurnaceMode::Off);
+  s.relay.fan = true;
+  ASSERT_TRUE(thermostat::compute_furnace_state(s) == FurnaceStateCode::FanOn);
+}
+
+TEST_CASE(thermostat_state_heat_relay_wins_over_mode) {
+  // If the heat relay is energized we report HeatOn regardless of mode —
+  // protects against UI lying about what the controller is actually doing.
+  ThermostatSnapshot s = make_snapshot(FurnaceMode::Cool);
+  s.relay.heat = true;
+  ASSERT_TRUE(thermostat::compute_furnace_state(s) == FurnaceStateCode::HeatOn);
+}
+
+TEST_CASE(thermostat_state_heat_relay_wins_over_cool_relay) {
+  // Both relays should never be on simultaneously, but if they are, heat is
+  // the safer thing to report (it's more visible / more concerning).
+  ThermostatSnapshot s = make_snapshot(FurnaceMode::Heat);
+  s.relay.heat = true;
+  s.relay.cool = true;
+  ASSERT_TRUE(thermostat::compute_furnace_state(s) == FurnaceStateCode::HeatOn);
+}
+
+TEST_CASE(thermostat_state_cool_relay_wins_over_fan_relay) {
+  ThermostatSnapshot s = make_snapshot(FurnaceMode::Cool);
+  s.relay.cool = true;
+  s.relay.fan = true;
+  ASSERT_TRUE(thermostat::compute_furnace_state(s) == FurnaceStateCode::CoolOn);
+}
+
+// --- compute_furnace_state: failsafe / lockout override everything ---
+
+TEST_CASE(thermostat_state_failsafe_returns_error_even_with_relays) {
+  ThermostatSnapshot s = make_snapshot(FurnaceMode::Heat);
+  s.relay.heat = true;
+  s.failsafe_active = true;
+  ASSERT_TRUE(thermostat::compute_furnace_state(s) == FurnaceStateCode::Error);
+}
+
+TEST_CASE(thermostat_state_lockout_returns_error_even_with_relays) {
+  ThermostatSnapshot s = make_snapshot(FurnaceMode::Cool);
+  s.relay.cool = true;
+  s.hvac_lockout = true;
+  ASSERT_TRUE(thermostat::compute_furnace_state(s) == FurnaceStateCode::Error);
+}
+
+TEST_CASE(thermostat_state_failsafe_returns_error_when_idle) {
+  ThermostatSnapshot s = make_snapshot(FurnaceMode::Off);
+  s.failsafe_active = true;
+  ASSERT_TRUE(thermostat::compute_furnace_state(s) == FurnaceStateCode::Error);
+}
+
+// --- compute_furnace_state: mode mapping when idle ---
+
+TEST_CASE(thermostat_state_idle_heat_mode_reports_heat_standby) {
+  ASSERT_TRUE(thermostat::compute_furnace_state(make_snapshot(FurnaceMode::Heat)) ==
+              FurnaceStateCode::HeatMode);
+}
+
+TEST_CASE(thermostat_state_idle_cool_mode_reports_cool_standby) {
+  ASSERT_TRUE(thermostat::compute_furnace_state(make_snapshot(FurnaceMode::Cool)) ==
+              FurnaceStateCode::CoolMode);
+}
+
+TEST_CASE(thermostat_state_idle_off_mode_reports_idle) {
+  ASSERT_TRUE(thermostat::compute_furnace_state(make_snapshot(FurnaceMode::Off)) ==
+              FurnaceStateCode::Idle);
+}
+
+TEST_CASE(thermostat_state_unknown_mode_reports_error) {
+  ThermostatSnapshot s;
+  s.mode = static_cast<FurnaceMode>(99);
+  ASSERT_TRUE(thermostat::compute_furnace_state(s) == FurnaceStateCode::Error);
+}
+
+// --- is_failsafe_timed_out ---
+
+TEST_CASE(thermostat_state_failsafe_timeout_with_no_heartbeat_yet) {
+  // heartbeat_last_seen_ms == 0 means we've never heard from the peer.
+  // Failsafe should trip once now exceeds the timeout.
+  ASSERT_TRUE(thermostat::is_failsafe_timed_out(10000, 0, 5000));
+  ASSERT_TRUE(!thermostat::is_failsafe_timed_out(3000, 0, 5000));
+}
+
+TEST_CASE(thermostat_state_failsafe_not_timed_out_when_recent) {
+  // 1s since last heartbeat, 5s timeout → not yet expired.
+  ASSERT_TRUE(!thermostat::is_failsafe_timed_out(11000, 10000, 5000));
+}
+
+TEST_CASE(thermostat_state_failsafe_timed_out_when_stale) {
+  // 6s since last heartbeat, 5s timeout → expired.
+  ASSERT_TRUE(thermostat::is_failsafe_timed_out(16000, 10000, 5000));
+}
+
+TEST_CASE(thermostat_state_failsafe_boundary_exact_timeout_not_expired) {
+  // Implementation uses strict greater-than, so equal-to-timeout is OK.
+  ASSERT_TRUE(!thermostat::is_failsafe_timed_out(15000, 10000, 5000));
+}
+
+TEST_CASE(thermostat_state_failsafe_handles_millis_wraparound) {
+  // millis() wraps at 2^32 ms (~49.7 days). With unsigned subtraction the
+  // delta computes correctly across the wrap. Last heartbeat just before
+  // wrap, "now" just after: only 100 ms have actually elapsed.
+  const uint32_t before_wrap = 0xFFFFFF00u;
+  const uint32_t after_wrap = 0x0000004Cu;  // 0xFFFFFF00 + 0x14C = wrap + 0x4C
+  ASSERT_TRUE(!thermostat::is_failsafe_timed_out(after_wrap, before_wrap, 5000));
+}
+
+#endif

--- a/src/tests/test_thermostat_ui_state.cpp
+++ b/src/tests/test_thermostat_ui_state.cpp
@@ -1,0 +1,53 @@
+#if defined(THERMOSTAT_RUN_TESTS)
+#include "thermostat/thermostat_ui_state.h"
+#include "test_harness.h"
+
+TEST_CASE(furnace_state_text_windows_open_in_cool_mode) {
+  std::string s = thermostat::furnace_state_text(
+      FurnaceStateCode::CoolMode, /*connected=*/true, /*lockout=*/false,
+      /*failsafe_active=*/false, /*windows_open=*/true, FurnaceMode::Cool);
+  ASSERT_STR_EQ(s.c_str(), "Windows Open");
+}
+
+TEST_CASE(furnace_state_text_windows_open_ignored_in_heat_mode) {
+  std::string s = thermostat::furnace_state_text(
+      FurnaceStateCode::HeatMode, /*connected=*/true, /*lockout=*/false,
+      /*failsafe_active=*/false, /*windows_open=*/true, FurnaceMode::Heat);
+  ASSERT_STR_EQ(s.c_str(), "Heat mode");
+}
+
+TEST_CASE(furnace_state_text_windows_open_ignored_in_off_mode) {
+  std::string s = thermostat::furnace_state_text(
+      FurnaceStateCode::Idle, /*connected=*/true, /*lockout=*/false,
+      /*failsafe_active=*/false, /*windows_open=*/true, FurnaceMode::Off);
+  ASSERT_STR_EQ(s.c_str(), "Idle");
+}
+
+TEST_CASE(furnace_state_text_failsafe_overrides_windows_open) {
+  std::string s = thermostat::furnace_state_text(
+      FurnaceStateCode::CoolMode, /*connected=*/true, /*lockout=*/false,
+      /*failsafe_active=*/true, /*windows_open=*/true, FurnaceMode::Cool);
+  ASSERT_STR_EQ(s.c_str(), "Failsafe");
+}
+
+TEST_CASE(furnace_state_text_lockout_overrides_windows_open) {
+  std::string s = thermostat::furnace_state_text(
+      FurnaceStateCode::CoolMode, /*connected=*/true, /*lockout=*/true,
+      /*failsafe_active=*/false, /*windows_open=*/true, FurnaceMode::Cool);
+  ASSERT_STR_EQ(s.c_str(), "Locked Out");
+}
+
+TEST_CASE(furnace_state_text_disconnected_overrides_windows_open) {
+  std::string s = thermostat::furnace_state_text(
+      FurnaceStateCode::CoolMode, /*connected=*/false, /*lockout=*/false,
+      /*failsafe_active=*/false, /*windows_open=*/true, FurnaceMode::Cool);
+  ASSERT_STR_EQ(s.c_str(), "Not Connected");
+}
+
+TEST_CASE(furnace_state_text_no_windows_open_returns_normal) {
+  std::string s = thermostat::furnace_state_text(
+      FurnaceStateCode::CoolOn, /*connected=*/true, /*lockout=*/false,
+      /*failsafe_active=*/false, /*windows_open=*/false, FurnaceMode::Cool);
+  ASSERT_STR_EQ(s.c_str(), "Cool on");
+}
+#endif

--- a/src/thermostat/esp32s3_thermostat_firmware.cpp
+++ b/src/thermostat/esp32s3_thermostat_firmware.cpp
@@ -310,6 +310,7 @@ uint32_t g_isolation_start_ms = 0;   // when both MQTT+ESP-NOW went down (0=not 
 // Shadow state for controller telemetry received via MQTT
 FurnaceStateCode g_mqtt_ctrl_state = FurnaceStateCode::Error;
 bool g_mqtt_ctrl_lockout = false;
+bool g_mqtt_ctrl_windows_open = false;
 FurnaceMode g_mqtt_ctrl_mode = FurnaceMode::Off;
 FanMode g_mqtt_ctrl_fan = FanMode::Automatic;
 float g_mqtt_ctrl_setpoint_c = 20.0f;
@@ -1741,6 +1742,9 @@ void mqtt_on_message(char *topic, uint8_t *payload, unsigned int length) {
     } else if (topic_str == controller_topic_for("state/lockout")) {
       g_mqtt_ctrl_lockout = mqtt_payload::parse_bool(value);
       g_mqtt_ctrl_last_update_ms = now;
+    } else if (topic_str == controller_topic_for("state/windows_open")) {
+      g_mqtt_ctrl_windows_open = mqtt_payload::parse_bool(value);
+      g_mqtt_ctrl_last_update_ms = now;
     } else if (topic_str == controller_topic_for("state/filter_runtime_hours")) {
       float hours = static_cast<float>(atof(value));
       if (std::isfinite(hours) && hours >= 0.0f) {
@@ -1859,6 +1863,7 @@ void ensure_mqtt_connected(uint32_t now_ms) {
     g_mqtt.subscribe(controller_topic_for("state/target_temp_c").c_str());
     g_mqtt.subscribe(controller_topic_for("state/furnace_state").c_str());
     g_mqtt.subscribe(controller_topic_for("state/lockout").c_str());
+    g_mqtt.subscribe(controller_topic_for("state/windows_open").c_str());
     g_mqtt.subscribe(controller_topic_for("state/filter_runtime_hours").c_str());
     g_mqtt.subscribe(controller_topic_for("state/outdoor_temp_c").c_str());
     g_mqtt.subscribe(controller_topic_for("state/weather_condition").c_str());
@@ -2907,7 +2912,8 @@ void thermostat_firmware_loop() {
     g_runtime->on_controller_state_update(
         now, g_mqtt_ctrl_state, g_mqtt_ctrl_lockout,
         g_mqtt_ctrl_mode, g_mqtt_ctrl_fan,
-        g_mqtt_ctrl_setpoint_c, g_mqtt_ctrl_filter_runtime_s);
+        g_mqtt_ctrl_setpoint_c, g_mqtt_ctrl_filter_runtime_s,
+        g_mqtt_ctrl_windows_open);
     g_mqtt_ctrl_last_applied_ms = g_mqtt_ctrl_last_update_ms;
     xSemaphoreGive(g_api_mutex);
   }

--- a/src/thermostat/thermostat_app.cpp
+++ b/src/thermostat/thermostat_app.cpp
@@ -52,6 +52,7 @@ void ThermostatApp::on_controller_telemetry(
   has_controller_telemetry_ = true;
   controller_state_ = telemetry.state;
   controller_lockout_ = telemetry.lockout;
+  controller_windows_open_ = telemetry.windows_open;
   controller_setpoint_c_ = telemetry.setpoint_c;
   controller_filter_runtime_seconds_ = telemetry.filter_runtime_seconds;
 
@@ -73,12 +74,14 @@ void ThermostatApp::on_controller_telemetry(
 
 void ThermostatApp::on_controller_state_update(
     uint32_t now_ms, FurnaceStateCode state, bool lockout, FurnaceMode mode,
-    FanMode fan, float setpoint_c, uint32_t filter_runtime_seconds) {
+    FanMode fan, float setpoint_c, uint32_t filter_runtime_seconds,
+    bool windows_open) {
   on_controller_heartbeat(now_ms);
 
   has_controller_telemetry_ = true;
   controller_state_ = state;
   controller_lockout_ = lockout;
+  controller_windows_open_ = windows_open;
   controller_setpoint_c_ = setpoint_c;
   controller_filter_runtime_seconds_ = filter_runtime_seconds;
 

--- a/src/thermostat/thermostat_device_runtime.cpp
+++ b/src/thermostat/thermostat_device_runtime.cpp
@@ -37,9 +37,11 @@ void ThermostatDeviceRuntime::on_outdoor_weather_update(float outdoor_temp_c,
 
 void ThermostatDeviceRuntime::on_controller_state_update(
     uint32_t now_ms, FurnaceStateCode state, bool lockout, FurnaceMode mode,
-    FanMode fan, float setpoint_c, uint32_t filter_runtime_seconds) {
+    FanMode fan, float setpoint_c, uint32_t filter_runtime_seconds,
+    bool windows_open) {
   display_.on_controller_state_update(now_ms, state, lockout, mode, fan,
-                                      setpoint_c, filter_runtime_seconds);
+                                      setpoint_c, filter_runtime_seconds,
+                                      windows_open);
 }
 
 void ThermostatDeviceRuntime::on_user_set_setpoint(float user_value, uint32_t now_ms) {

--- a/src/thermostat/thermostat_display_app.cpp
+++ b/src/thermostat/thermostat_display_app.cpp
@@ -32,9 +32,10 @@ void ThermostatDisplayApp::on_outdoor_weather_update(float outdoor_temp_c,
 
 void ThermostatDisplayApp::on_controller_state_update(
     uint32_t now_ms, FurnaceStateCode state, bool lockout, FurnaceMode mode,
-    FanMode fan, float setpoint_c, uint32_t filter_runtime_seconds) {
+    FanMode fan, float setpoint_c, uint32_t filter_runtime_seconds,
+    bool windows_open) {
   app_.on_controller_state_update(now_ms, state, lockout, mode, fan, setpoint_c,
-                                  filter_runtime_seconds);
+                                  filter_runtime_seconds, windows_open);
   sync_from_app();
 }
 

--- a/src/thermostat/thermostat_display_app.cpp
+++ b/src/thermostat/thermostat_display_app.cpp
@@ -61,10 +61,14 @@ void ThermostatDisplayApp::on_user_set_fan_mode(FanMode mode, uint32_t now_ms) {
 std::string ThermostatDisplayApp::status_text(uint32_t now_ms,
                                               uint32_t connection_timeout_ms) const {
   const bool connected = app_.controller_connected(now_ms, connection_timeout_ms);
-  const bool lockout = app_.has_controller_telemetry() ? app_.controller_lockout() : false;
+  const bool has_tel = app_.has_controller_telemetry();
+  const bool lockout = has_tel ? app_.controller_lockout() : false;
+  const bool windows_open = has_tel ? app_.controller_windows_open() : false;
   const auto state =
-      app_.has_controller_telemetry() ? app_.controller_state() : FurnaceStateCode::Error;
-  return furnace_state_text(state, connected, lockout, false);
+      has_tel ? app_.controller_state() : FurnaceStateCode::Error;
+  const FurnaceMode mode = app_.local_mode();
+  return furnace_state_text(state, connected, lockout, /*failsafe_active=*/false,
+                            windows_open, mode);
 }
 
 }  // namespace thermostat

--- a/src/thermostat/thermostat_ui_state.cpp
+++ b/src/thermostat/thermostat_ui_state.cpp
@@ -5,7 +5,9 @@ namespace thermostat {
 std::string furnace_state_text(FurnaceStateCode state,
                                bool connected,
                                bool lockout,
-                               bool failsafe_active) {
+                               bool failsafe_active,
+                               bool windows_open,
+                               FurnaceMode mode) {
   if (failsafe_active) {
     return "Failsafe";
   }
@@ -14,6 +16,9 @@ std::string furnace_state_text(FurnaceStateCode state,
   }
   if (!connected) {
     return "Not Connected";
+  }
+  if (windows_open && mode == FurnaceMode::Cool) {
+    return "Windows Open";
   }
 
   switch (state) {

--- a/src/thermostat/transport/espnow_thermostat_transport.cpp
+++ b/src/thermostat/transport/espnow_thermostat_transport.cpp
@@ -217,7 +217,8 @@ void EspNowThermostatTransport::on_recv(const uint8_t *src_mac,
         ThermostatControllerTelemetry telemetry;
         telemetry.seq = pkt->seq;
         telemetry.state = static_cast<FurnaceStateCode>(pkt->state);
-        telemetry.lockout = pkt->lockout != 0;
+        telemetry.lockout = (pkt->lockout & 0x01) != 0;
+        telemetry.windows_open = (pkt->lockout & 0x02) != 0;
         telemetry.mode_code = pkt->mode;
         telemetry.fan_code = pkt->fan;
         telemetry.setpoint_c = static_cast<float>(pkt->setpoint_decic) / 10.0f;


### PR DESCRIPTION
## Summary
- Adds a `windows_open` state on the controller that suppresses cooling demand while the A/C is the active mode, surfaced via MQTT (cmd/state/discovery) and ESP-NOW (lockout byte bit 1).
- Display tracks the flag via both transports and shows "Windows Open" in the status text when Cool is active; sim has toggle + MQTT parity.
- Includes discovery cleanup for the new entity and broad test coverage (controller runtime, mqtt_payload, thermostat_state, UI state, display model).

## Test plan
- [ ] `pio run -e native-tests` and run `.pio/build/native-tests/program`
- [ ] Build controller + thermostat firmware
- [ ] OTA flash bench devices; verify MQTT `windows_open` cmd toggles state and disables cooling demand while in Cool
- [ ] Confirm display shows "Windows Open" status text in Cool mode and clears when toggled off
- [ ] Verify HA discovery entity appears and is removed on cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)