### PR TITLE
Persist reboot cause to NVS for controller reboot diagnostics

### DIFF
--- a/include/wifi_watchdog.h
+++ b/include/wifi_watchdog.h
@@ -37,6 +37,11 @@ struct State {
 
 static State g_state;
 
+// Optional hook invoked with a human-readable reason immediately before the
+// watchdog forces a reboot. Lets the application persist the cause (e.g. to
+// NVS) so it survives the reboot. No-op if unset.
+static void (*g_reboot_hook)(const char *reason) = nullptr;
+
 static void on_ping_success(esp_ping_handle_t hdl, void *args) {
     static_cast<State *>(args)->ping_got_reply = true;
 }
@@ -153,6 +158,14 @@ static void handle_ping_result(uint32_t now_ms) {
         Serial.printf("[watchdog]   reason: failure_duration=%lus reconnects=%lu\n",
                       (unsigned long)(failure_duration / 1000),
                       (unsigned long)g_state.reconnect_count);
+        if (g_reboot_hook) {
+            char reason[64];
+            snprintf(reason, sizeof(reason),
+                     "wifi_watchdog: gateway unreachable %lus reconnects=%lu",
+                     (unsigned long)(failure_duration / 1000),
+                     (unsigned long)g_state.reconnect_count);
+            g_reboot_hook(reason);
+        }
         Serial.flush();
         delay(100);
         ESP.restart();
@@ -169,6 +182,12 @@ static void handle_ping_result(uint32_t now_ms) {
 }
 
 } // namespace wifi_watchdog
+
+// Register a callback invoked with the reboot reason just before the watchdog
+// forces a reboot. Pass nullptr to disable.
+inline void wifi_watchdog_set_reboot_hook(void (*hook)(const char *reason)) {
+    wifi_watchdog::g_reboot_hook = hook;
+}
 
 // connectivity_proven: pass true when the application layer (e.g. MQTT) is
 // confirmed working — this proves WiFi is healthy, so skip the gateway ping

--- a/src/esp32_controller_main.cpp
+++ b/src/esp32_controller_main.cpp
@@ -73,6 +73,10 @@ DeviceRegistry g_device_registry;
 bool g_ctrl_mdns_started = false;
 uint32_t g_ctrl_boot_count = 0;
 String g_ctrl_reset_reason = "unknown";
+// Cause of the firmware-initiated reboot that immediately preceded this boot,
+// recovered from NVS at startup. "none" means the last reset was not one of the
+// instrumented esp_restart() paths (power-on, panic, brownout, OTA, etc.).
+String g_ctrl_reboot_reason = "none";
 bool g_ctrl_reboot_requested = false;
 uint32_t g_ctrl_reboot_at_ms = 0;
 uint32_t g_ctrl_isolation_start_ms = 0;  // 0 = not isolated
@@ -368,7 +372,21 @@ static String get_first_display_mac() {
 }
 
 
-void ctrl_schedule_reboot() {
+// Record the cause of an imminent firmware-initiated reboot to NVS so it can be
+// read back and published after the device comes up again. Appends uptime,
+// which distinguishes a boot-loop (low uptime) from a long-running drift.
+void ctrl_persist_reboot_reason(const char *reason) {
+  if (!g_ctrl_cfg_ready || reason == nullptr) {
+    return;
+  }
+  char buf[96];
+  snprintf(buf, sizeof(buf), "%s uptime=%lus", reason,
+           static_cast<unsigned long>(millis() / 1000UL));
+  g_ctrl_cfg.putString("reboot_why", buf);
+}
+
+void ctrl_schedule_reboot(const char *reason) {
+  ctrl_persist_reboot_reason(reason);
   g_ctrl_reboot_requested = true;
   g_ctrl_reboot_at_ms = millis() + 250;
 }
@@ -776,6 +794,7 @@ void ctrl_poll_weather(uint32_t now_ms) {
     // (HTTPClient, WiFiClientSecure) since their destructors won't run.
     // Rebooting is the only safe recovery from a hung TLS call.
     ctrl_audit("ctrl_weather: task wedged, rebooting to recover");
+    ctrl_persist_reboot_reason("weather_wedge: weather task heartbeat stale");
     esp_restart();
   }
   if (!g_ctrl_weather_pending.ready.load(std::memory_order_acquire) ||
@@ -812,6 +831,12 @@ void ctrl_publish_discovery() {
   const String fw_topic = dp + "sensor/" + dev_id + "_controller_firmware/config";
   const String rssi_topic = dp + "sensor/" + dev_id + "_controller_wifi_rssi/config";
   const String heap_topic = dp + "sensor/" + dev_id + "_controller_free_heap/config";
+  const String reset_reason_topic =
+      dp + "sensor/" + dev_id + "_controller_reset_reason/config";
+  const String reboot_reason_topic =
+      dp + "sensor/" + dev_id + "_controller_reboot_reason/config";
+  const String boot_count_topic =
+      dp + "sensor/" + dev_id + "_controller_boot_count/config";
   const String last_mqtt_cmd_topic =
       dp + "sensor/" + dev_id + "_controller_last_mqtt_command/config";
   const String last_espnow_rx_topic =
@@ -914,6 +939,28 @@ void ctrl_publish_discovery() {
            "\"entity_category\":\"diagnostic\",\"en\":false,\"dev\":{\"ids\":[\"%s\"]}}",
            dev_id.c_str(), base.c_str(), dev_id.c_str());
   g_ctrl_mqtt.publish(heap_topic.c_str(), payload, true);
+
+  snprintf(payload, sizeof(payload),
+           "{\"name\":\"Controller Reset Reason\",\"uniq_id\":\"%s_controller_reset_reason\","
+           "\"stat_t\":\"%s/state/reset_reason\",\"entity_category\":\"diagnostic\","
+           "\"icon\":\"mdi:restart\",\"dev\":{\"ids\":[\"%s\"]}}",
+           dev_id.c_str(), base.c_str(), dev_id.c_str());
+  g_ctrl_mqtt.publish(reset_reason_topic.c_str(), payload, true);
+
+  snprintf(payload, sizeof(payload),
+           "{\"name\":\"Controller Reboot Cause\",\"uniq_id\":\"%s_controller_reboot_reason\","
+           "\"stat_t\":\"%s/state/reboot_reason\",\"entity_category\":\"diagnostic\","
+           "\"icon\":\"mdi:alert-circle-outline\",\"dev\":{\"ids\":[\"%s\"]}}",
+           dev_id.c_str(), base.c_str(), dev_id.c_str());
+  g_ctrl_mqtt.publish(reboot_reason_topic.c_str(), payload, true);
+
+  snprintf(payload, sizeof(payload),
+           "{\"name\":\"Controller Boot Count\",\"uniq_id\":\"%s_controller_boot_count\","
+           "\"stat_t\":\"%s/state/boot_count\",\"stat_cla\":\"total_increasing\","
+           "\"entity_category\":\"diagnostic\",\"icon\":\"mdi:counter\","
+           "\"dev\":{\"ids\":[\"%s\"]}}",
+           dev_id.c_str(), base.c_str(), dev_id.c_str());
+  g_ctrl_mqtt.publish(boot_count_topic.c_str(), payload, true);
 
   snprintf(payload, sizeof(payload),
            "{\"name\":\"Controller Last MQTT Command\",\"uniq_id\":\"%s_controller_last_mqtt_command\","
@@ -1173,7 +1220,7 @@ void ctrl_web_handle_config_post() {
 }
 
 void ctrl_web_handle_reboot_post() {
-  ctrl_schedule_reboot();
+  ctrl_schedule_reboot("scheduled: web /reboot");
   g_ctrl_web.send(200, "text/plain", "rebooting\n");
 }
 
@@ -1631,6 +1678,8 @@ void ctrl_publish_runtime_state() {
   g_ctrl_mqtt.publish(self_topic_for("state/boot_count").c_str(), buf, true);
   g_ctrl_mqtt.publish(self_topic_for("state/reset_reason").c_str(), g_ctrl_reset_reason.c_str(),
                       true);
+  g_ctrl_mqtt.publish(self_topic_for("state/reboot_reason").c_str(),
+                      g_ctrl_reboot_reason.c_str(), true);
   snprintf(buf, sizeof(buf), "%lu", static_cast<unsigned long>(millis() / 1000UL));
   g_ctrl_mqtt.publish(self_topic_for("state/uptime_s").c_str(), buf, true);
   snprintf(buf, sizeof(buf), "%lu", static_cast<unsigned long>(g_ctrl_last_mqtt_command_ms));
@@ -1969,7 +2018,7 @@ void ctrl_mqtt_on_message(char *topic, uint8_t *payload, unsigned int length) {
     return;
   }
   if (topic_str == self_topic_for("cmd/reboot") && mqtt_payload::parse_bool(value)) {
-    ctrl_schedule_reboot();
+    ctrl_schedule_reboot("scheduled: mqtt cmd/reboot");
     return;
   }
   if (topic_str == self_topic_for("cmd/reset_sequence") && mqtt_payload::parse_bool(value)) {
@@ -2125,6 +2174,19 @@ void setup() {
     g_ctrl_cfg.putUInt("boot_cnt", g_ctrl_boot_count);
   }
   g_ctrl_reset_reason = ctrl_reset_reason_text(esp_reset_reason());
+  // Recover and clear the persisted cause of the preceding firmware reboot.
+  // Cleared after reading so an uninstrumented reset (panic/brownout/power-on)
+  // is reported as "none" rather than the stale prior cause.
+  if (g_ctrl_cfg_ready) {
+    g_ctrl_reboot_reason = g_ctrl_cfg.getString("reboot_why", "none");
+    if (g_ctrl_reboot_reason.isEmpty()) {
+      g_ctrl_reboot_reason = "none";
+    }
+    g_ctrl_cfg.remove("reboot_why");
+  }
+  Serial.printf("Reset reason: %s | last reboot cause: %s\n",
+                g_ctrl_reset_reason.c_str(), g_ctrl_reboot_reason.c_str());
+  wifi_watchdog_set_reboot_hook(&ctrl_persist_reboot_reason);
 
   thermostat::ControllerConfig controller_cfg;
   controller_cfg.failsafe_timeout_ms = 300000;
@@ -2316,6 +2378,14 @@ void loop() {
                    static_cast<unsigned long>((now - g_ctrl_isolation_start_ms) / 1000),
                    g_ctrl_mqtt.connected() ? 1 : 0,
                    static_cast<unsigned long>(hb_ms));
+        {
+          char reason[80];
+          snprintf(reason, sizeof(reason),
+                   "isolation: mqtt+espnow down %lus",
+                   static_cast<unsigned long>(
+                       (now - g_ctrl_isolation_start_ms) / 1000));
+          ctrl_persist_reboot_reason(reason);
+        }
         ESP.restart();
       }
     }


### PR DESCRIPTION
## Summary

The controller reboots ~2×/day with `reset_reason = software`, but the cause can't be determined: all four firmware-initiated reboot paths report identically as `ESP_RST_SW`, and the audit line naming the path is published **non-retained** — so it's destroyed by the reboot it describes.

This adds persistent reboot-cause instrumentation so the **next** reboot reveals which path fired:

- New `ctrl_persist_reboot_reason()` writes a cause string **+ uptime** to NVS (`cfg_ctrl/reboot_why`) immediately before each `esp_restart()`/`ESP.restart()`. Uptime distinguishes a boot-loop (low) from slow drift (high).
- Wired into all four paths: weather-task wedge, WiFi watchdog (zombie-WiFi), isolation reboot, and scheduled reboot (web `/reboot` + MQTT `cmd/reboot`).
- On boot the cause is recovered, logged to serial, then **cleared** — so an uninstrumented reset (panic/brownout/power-on/OTA) reports `none` rather than a stale prior cause.
- Published retained to `state/reboot_reason`.
- Added HA discovery sensors for **Reboot Cause**, **Reset Reason**, and **Boot Count**. The latter two were already published retained but had no discovery entity — which is why the reboots were invisible in Home Assistant.

The WiFi watchdog lives in a shared header (`wifi_watchdog.h`); it now exposes an opt-in `wifi_watchdog_set_reboot_hook()` so the controller can record that path without affecting the thermostat build (which never sets the hook).

Note: this is diagnostic-only — it does **not** change any reboot behavior. Investigation also found the issue's analysis had missed the WiFi-watchdog path entirely.

Refs #28

## Test plan

- [x] `pio run -e esp32-furnace-controller` builds
- [x] `pio run -e esp32-furnace-thermostat` builds (shared header unaffected)
- [x] `pio run -e native-tests` — 151/151 pass
- [ ] Flash controller; after next reboot, confirm `Controller Reboot Cause` sensor names the path + uptime

🤖 Generated with [Claude Code](https://claude.com/claude-code)