### PR TITLE
fix(firmware): stop task_wdt resets from PubSubClient connect busy-spin

### DIFF
--- a/src/esp32_controller_main.cpp
+++ b/src/esp32_controller_main.cpp
@@ -33,6 +33,7 @@
 #include <WebServer.h>
 #include <esp_mac.h>
 #include <esp_system.h>
+#include <esp_task_wdt.h>
 #include "ota_web_updater.h"
 #include "controller/audit_log.h"
 #include "web/web_ui_escape.h"
@@ -81,11 +82,79 @@ bool g_ctrl_reboot_requested = false;
 uint32_t g_ctrl_reboot_at_ms = 0;
 uint32_t g_ctrl_isolation_start_ms = 0;  // 0 = not isolated
 
+// --- Task Watchdog breadcrumb -----------------------------------------------
+// A hard Task-WDT panic doesn't run our reboot hook, so reboot_reason stays
+// "none". To learn *which* blocking network call was running when the watchdog
+// fired, stamp a breadcrumb into RTC_NOINIT memory (survives a watchdog/panic/SW
+// reset, but not power-on/brownout) before each blocking call and clear it
+// after. On the next boot we recover and publish it alongside reset_reason.
+enum CtrlBlockingSection : uint32_t {
+  kCtrlSectionNone = 0,
+  kCtrlSectionWeatherGeocode = 1,
+  kCtrlSectionWeatherForecast = 2,
+  kCtrlSectionMqttConnect = 3,
+  kCtrlSectionMdns = 4,
+};
+constexpr uint32_t kCtrlBreadcrumbMagic = 0x57445443u;  // 'WDTC'
+constexpr size_t kCtrlCoreCount = 2;  // dual-core ESP32
+RTC_NOINIT_ATTR static uint32_t g_ctrl_breadcrumb_magic;
+// One slot per core (indexed by xPortGetCoreID) so the weather task (core 0) and
+// the main loop / MQTT path (core 1) never race on a shared word. Each core only
+// writes its own slot, so the recovered breadcrumb is unambiguous.
+RTC_NOINIT_ATTR static volatile uint32_t g_ctrl_breadcrumb_section[kCtrlCoreCount];
+// Per-core section active at the prior boot's reset, captured once at boot.
+// "none" if the reset happened outside any instrumented blocking call (or power-on).
+String g_ctrl_wdt_section = "none";
+
+static inline void ctrl_breadcrumb_set(CtrlBlockingSection s) {
+  g_ctrl_breadcrumb_section[xPortGetCoreID()] = static_cast<uint32_t>(s);
+}
+static inline void ctrl_breadcrumb_clear() {
+  g_ctrl_breadcrumb_section[xPortGetCoreID()] = static_cast<uint32_t>(kCtrlSectionNone);
+}
+static const char *ctrl_breadcrumb_text(uint32_t s) {
+  switch (s) {
+    case kCtrlSectionWeatherGeocode: return "weather_geocode";
+    case kCtrlSectionWeatherForecast: return "weather_forecast";
+    case kCtrlSectionMqttConnect: return "mqtt_connect";
+    case kCtrlSectionMdns: return "mdns";
+    default: return "none";
+  }
+}
+// Recover the breadcrumb left by a prior boot. Call once in setup(). On power-on
+// the RTC magic is invalid (garbage), so we initialize instead of reading.
+static void ctrl_breadcrumb_recover_on_boot() {
+  if (g_ctrl_breadcrumb_magic != kCtrlBreadcrumbMagic) {
+    g_ctrl_breadcrumb_magic = kCtrlBreadcrumbMagic;
+    g_ctrl_wdt_section = "none";
+  } else if (g_ctrl_breadcrumb_section[0] == kCtrlSectionNone &&
+             g_ctrl_breadcrumb_section[1] == kCtrlSectionNone) {
+    g_ctrl_wdt_section = "none";
+  } else {
+    g_ctrl_wdt_section = String("core0=") +
+                         ctrl_breadcrumb_text(g_ctrl_breadcrumb_section[0]) +
+                         " core1=" + ctrl_breadcrumb_text(g_ctrl_breadcrumb_section[1]);
+  }
+  for (size_t i = 0; i < kCtrlCoreCount; ++i) {
+    g_ctrl_breadcrumb_section[i] = static_cast<uint32_t>(kCtrlSectionNone);
+  }
+}
+
 constexpr uint32_t kCtrlNetworkRetryMs = 5000;
 constexpr uint32_t kCtrlMqttPublishMs = 10000;
 constexpr uint32_t kCtrlMqttPrimaryHoldMs = 30000;
 constexpr uint32_t kCtrlWeatherPollMs = 15UL * 60UL * 1000UL;
-constexpr uint32_t kCtrlHttpTimeoutMs = 8000;
+// Per-phase HTTP timeout (connect+handshake and read). Kept well below the Task
+// Watchdog timeout (kCtrlTaskWdtTimeoutMs) so a stalled fetch aborts long before
+// the watchdog would panic.
+constexpr uint32_t kCtrlHttpTimeoutMs = 4000;
+// Steady-state Task Watchdog timeout. Set explicitly in setup() (and mirrored in
+// ota_web_updater.cpp's post-OTA restore) so behavior is deterministic regardless
+// of the Arduino default. Must exceed every synchronous network timeout above.
+constexpr uint32_t kCtrlTaskWdtTimeoutMs = 15000;
+// PubSubClient socket timeout (seconds). Below the watchdog so a stuck MQTT
+// connect/read aborts before a panic.
+constexpr uint8_t kCtrlMqttSocketTimeoutS = 5;
 // Reboot if both MQTT and ESP-NOW have been silent for this long.
 // Covers wedged network-stack states that the WiFi watchdog ping doesn't catch.
 constexpr uint32_t kCtrlIsolationRebootMs = 15UL * 60UL * 1000UL;
@@ -660,13 +729,17 @@ bool ctrl_fetch_zip_coordinates(const char *zip, float *lat_out, float *lon_out)
     return false;
   }
   http.setTimeout(kCtrlHttpTimeoutMs);
+  http.setConnectTimeout(kCtrlHttpTimeoutMs);
+  ctrl_breadcrumb_set(kCtrlSectionWeatherGeocode);
   const int status = http.GET();
   if (status != 200) {
+    ctrl_breadcrumb_clear();
     ctrl_audit("weather: geocode HTTP %d for zip %s", status, zip);
     http.end();
     return false;
   }
   const String body = http.getString();
+  ctrl_breadcrumb_clear();
   http.end();
   return pirateweather::parse_geocode_response(body.c_str(), lat_out, lon_out);
 }
@@ -687,13 +760,17 @@ bool ctrl_fetch_pirateweather_current(float lat, float lon, const char *api_key,
     return false;
   }
   http.setTimeout(kCtrlHttpTimeoutMs);
+  http.setConnectTimeout(kCtrlHttpTimeoutMs);
+  ctrl_breadcrumb_set(kCtrlSectionWeatherForecast);
   const int status = http.GET();
   if (status != 200) {
+    ctrl_breadcrumb_clear();
     ctrl_audit("weather: forecast HTTP %d", status);
     http.end();
     return false;
   }
   const String body = http.getString();
+  ctrl_breadcrumb_clear();
   http.end();
   return pirateweather::parse_forecast_response(body.c_str(), temp_c_out,
                                                 icon_out);
@@ -835,6 +912,8 @@ void ctrl_publish_discovery() {
       dp + "sensor/" + dev_id + "_controller_reset_reason/config";
   const String reboot_reason_topic =
       dp + "sensor/" + dev_id + "_controller_reboot_reason/config";
+  const String wdt_section_topic =
+      dp + "sensor/" + dev_id + "_controller_wdt_section/config";
   const String boot_count_topic =
       dp + "sensor/" + dev_id + "_controller_boot_count/config";
   const String last_mqtt_cmd_topic =
@@ -953,6 +1032,13 @@ void ctrl_publish_discovery() {
            "\"icon\":\"mdi:alert-circle-outline\",\"dev\":{\"ids\":[\"%s\"]}}",
            dev_id.c_str(), base.c_str(), dev_id.c_str());
   g_ctrl_mqtt.publish(reboot_reason_topic.c_str(), payload, true);
+
+  snprintf(payload, sizeof(payload),
+           "{\"name\":\"Controller WDT Section\",\"uniq_id\":\"%s_controller_wdt_section\","
+           "\"stat_t\":\"%s/state/wdt_section\",\"entity_category\":\"diagnostic\","
+           "\"icon\":\"mdi:map-marker-path\",\"dev\":{\"ids\":[\"%s\"]}}",
+           dev_id.c_str(), base.c_str(), dev_id.c_str());
+  g_ctrl_mqtt.publish(wdt_section_topic.c_str(), payload, true);
 
   snprintf(payload, sizeof(payload),
            "{\"name\":\"Controller Boot Count\",\"uniq_id\":\"%s_controller_boot_count\","
@@ -1680,6 +1766,8 @@ void ctrl_publish_runtime_state() {
                       true);
   g_ctrl_mqtt.publish(self_topic_for("state/reboot_reason").c_str(),
                       g_ctrl_reboot_reason.c_str(), true);
+  g_ctrl_mqtt.publish(self_topic_for("state/wdt_section").c_str(),
+                      g_ctrl_wdt_section.c_str(), true);
   snprintf(buf, sizeof(buf), "%lu", static_cast<unsigned long>(millis() / 1000UL));
   g_ctrl_mqtt.publish(self_topic_for("state/uptime_s").c_str(), buf, true);
   snprintf(buf, sizeof(buf), "%lu", static_cast<unsigned long>(g_ctrl_last_mqtt_command_ms));
@@ -2090,6 +2178,7 @@ void ctrl_ensure_mqtt_connected(uint32_t now_ms) {
 
   bool ok = false;
   String will_topic = self_topic_for("state/availability");
+  ctrl_breadcrumb_set(kCtrlSectionMqttConnect);
   if (g_cfg_ctrl_mqtt_user.length() == 0) {
     ok = g_ctrl_mqtt.connect(g_cfg_ctrl_mqtt_client_id.c_str(),
                              will_topic.c_str(), 1, true, "offline");
@@ -2098,6 +2187,7 @@ void ctrl_ensure_mqtt_connected(uint32_t now_ms) {
                              g_cfg_ctrl_mqtt_user.c_str(), g_cfg_ctrl_mqtt_password.c_str(),
                              will_topic.c_str(), 1, true, "offline");
   }
+  ctrl_breadcrumb_clear();
   if (!ok) {
     g_ctrl_last_mqtt_error = String("connect_state_") + String(g_ctrl_mqtt.state());
     return;
@@ -2154,7 +2244,10 @@ void ctrl_ensure_mdns_ready() {
   }
   const char *host = g_cfg_ctrl_hostname.length() > 0 ? g_cfg_ctrl_hostname.c_str()
                                                            : "furnace-controller";
-  if (MDNS.begin(host)) {
+  ctrl_breadcrumb_set(kCtrlSectionMdns);
+  const bool mdns_ok = MDNS.begin(host);
+  ctrl_breadcrumb_clear();
+  if (mdns_ok) {
     MDNS.addService("http", "tcp", 80);
     g_ctrl_mdns_started = true;
   }
@@ -2174,6 +2267,10 @@ void setup() {
     g_ctrl_cfg.putUInt("boot_cnt", g_ctrl_boot_count);
   }
   g_ctrl_reset_reason = ctrl_reset_reason_text(esp_reset_reason());
+  // Recover which instrumented blocking call (if any) was running when the
+  // preceding reset occurred. Surfaced via state/wdt_section to diagnose
+  // task_wdt panics that leave reboot_reason="none".
+  ctrl_breadcrumb_recover_on_boot();
   // Recover and clear the persisted cause of the preceding firmware reboot.
   // Cleared after reading so an uninstrumented reset (panic/brownout/power-on)
   // is reported as "none" rather than the stale prior cause.
@@ -2187,6 +2284,20 @@ void setup() {
   Serial.printf("Reset reason: %s | last reboot cause: %s\n",
                 g_ctrl_reset_reason.c_str(), g_ctrl_reboot_reason.c_str());
   wifi_watchdog_set_reboot_hook(&ctrl_persist_reboot_reason);
+
+  // Make the Task Watchdog config deterministic regardless of the Arduino
+  // default: 15s timeout, watch both cores' idle tasks, panic on timeout. Every
+  // synchronous network timeout (HTTP, MQTT) is kept below this. Mirrored by
+  // ota_web_updater.cpp's post-OTA restore.
+  {
+    esp_task_wdt_config_t wdt_cfg = {
+        .timeout_ms = kCtrlTaskWdtTimeoutMs,
+        .idle_core_mask = 0x3,  // both cores (dual-core ESP32)
+        .trigger_panic = true,
+    };
+    esp_task_wdt_reconfigure(&wdt_cfg);
+  }
+  g_ctrl_mqtt.setSocketTimeout(kCtrlMqttSocketTimeoutS);
 
   thermostat::ControllerConfig controller_cfg;
   controller_cfg.failsafe_timeout_ms = 300000;
@@ -2295,6 +2406,10 @@ void setup() {
   g_relay_io.begin();
   Serial.printf("controller_node_begin=%u\n", static_cast<unsigned>(ok));
   ctrl_audit("boot ok, espnow=%s", ok ? "true" : "false");
+  if (g_ctrl_wdt_section != "none") {
+    ctrl_audit("prev reset in blocking section: %s (reset=%s)",
+               g_ctrl_wdt_section.c_str(), g_ctrl_reset_reason.c_str());
+  }
   ota_rollback_begin();
 
   // Web server task on Core 0: handles HTTP requests without blocking the

--- a/src/ota_web_updater.cpp
+++ b/src/ota_web_updater.cpp
@@ -246,9 +246,13 @@ static void handle_update_upload(WebServer &server) {
         ota_audit("ota_web: end failed after %u bytes", upload.totalSize);
       }
       {
+        // Restore the steady-state Task Watchdog config (keep in sync with
+        // kCtrlTaskWdtTimeoutMs / setup() in esp32_controller_main.cpp): 15s,
+        // watching both cores' idle tasks. Previously left at mask=0, which
+        // disabled the watchdog until the next reboot.
         esp_task_wdt_config_t wdt_cfg = {
-            .timeout_ms = 5000,
-            .idle_core_mask = 0,
+            .timeout_ms = 15000,
+            .idle_core_mask = 0x3,
             .trigger_panic = true,
         };
         esp_task_wdt_reconfigure(&wdt_cfg);

--- a/src/thermostat/esp32s3_thermostat_firmware.cpp
+++ b/src/thermostat/esp32s3_thermostat_firmware.cpp
@@ -2812,6 +2812,21 @@ void thermostat_firmware_setup() {
     Serial.println("[web] FATAL: failed to allocate web task stack");
   }
   esp_task_wdt_add(NULL);  // register main task with TWDT
+  // Raise the Task Watchdog timeout to 15s so a bounded MQTT-connect spin (see
+  // setSocketTimeout below) can't starve the main task's esp_task_wdt_reset().
+  // idle_core_mask=0: the display's explicit main+web task registration remains
+  // the watchdog coverage (esp_task_wdt_add calls are unaffected by reconfigure).
+  {
+    esp_task_wdt_config_t wdt_cfg = {
+        .timeout_ms = 15000,
+        .idle_core_mask = 0,
+        .trigger_panic = true,
+    };
+    esp_task_wdt_reconfigure(&wdt_cfg);
+  }
+  // Bound PubSubClient's connect/read busy-wait (PubSubClient.cpp:257 spins with
+  // no yield for up to socketTimeout) to 5s, well under the 15s watchdog.
+  g_mqtt.setSocketTimeout(5);
 }
 
 void thermostat_firmware_loop() {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,59 +1,102 @@
 # TODO
 
-- [x] When mode is set to Off, hide the setpoint (+/-) buttons on the display UI
-- [x] Add filter change indicator on the home screen below indoor humidity
+## Controller stability: task_wdt resets
 
-## Issue #22 — Separate setpoints for heat and cool modes
+### Problem
+Controller (and display) report `reset_reason=task_wdt` with `reboot_reason=none`
+— hard Task Watchdog panics, *not* the firmware's graceful self-reboots. Root
+cause: synchronous blocking network calls run longer than the ~5s TWDT timeout,
+starving an idle task. Two paths qualify:
+- **Weather HTTPS fetch** (async task on Core 0): `kCtrlHttpTimeoutMs = 8000` (8s) > 5s TWDT.
+- **MQTT connect** (inline in `loop()`, Core 1): PubSubClient default 15s socket timeout.
 
-### Goal
-Persist independent heat and cool setpoints on the controller so that switching modes restores the previously-used setpoint for that mode (instead of carrying over the other mode's value).
+Regression: the async weather task (2026-03-02) and Core-0 web task (2026-03-10)
+exposed these blocking calls to the per-core idle-task watchdog after initial
+bring-up. Weak WiFi (RSSI −75 dBm) makes the stalls more frequent → intermittent
+(not a tight loop; 39+ min healthy uptime observed).
 
-### Design summary
-- **Source of truth: controller.** Add `heat_setpoint_c_` and `cool_setpoint_c_` to `ControllerRuntime` (defaults 20°C heat, 24°C cool). `target_temperature_c()` returns the bin matching `mode_` (Off → last-used bin; doesn't affect HVAC).
-- **Routing on command:** `apply_remote_command` stores `cmd.setpoint` into the bin matching `cmd.mode` (Heat → heat bin; Cool → cool bin; Off → leave both alone but still apply mode change). Any sender — display, MQTT, HA — that sends `(mode, setpoint)` together always targets the matching bin.
-- **Wire format:** No change. `CommandWord` and `ControllerTelemetryPacket` still carry one setpoint (the active one). Protocol version unchanged.
-- **Display side:** Track `local_heat_setpoint_c_` and `local_cool_setpoint_c_` in `ThermostatApp`. When user switches mode, display sends the bin matching the new mode (so cool→heat doesn't overwrite the controller's stored cool bin). Both bins seed from telemetry into the bin matching telemetry's mode_code, so the display learns each bin the first time the controller reports that mode.
-- **Persistence (controller NVS):** New keys `hvac_heat_sp_c` and `hvac_cool_sp_c`. On boot, if new keys missing, seed both from legacy `hvac_sp_c` (one-time migration).
-- **MQTT/HA:** Keep single `cmd/target_temp_c` endpoint. The setpoint targets the *current mode's* bin via the normal CommandWord path. `state/target_temp_c` publishes the active bin. No discovery payload changes needed.
+### Decisions (confirmed with user)
+- Crash capture: **RTC-memory breadcrumb** (coredump-to-flash infeasible — 4 MB flash
+  fully partitioned, partition change needs physical reflash, no serial available).
+- Timeouts: **TWDT 15s / HTTP 4s (connect + read) / PubSub 5s** — every app-level
+  timeout fires well before the 15s watchdog (defense in depth).
+- Scope: controller + display. Both share the PubSubClient busy-spin root cause.
+  Display fix differs: it explicitly registers its main+web tasks with the TWDT
+  (esp_task_wdt_add/reset) at the default ~5s, so it gets setSocketTimeout(5) +
+  a TWDT bump to 15s (idle_core_mask=0, preserving its explicit-task model).
 
 ### Tasks
-- [x] Add `heat_setpoint_c_` / `cool_setpoint_c_` to `ControllerRuntime`; update `target_temperature_c()`; route `apply_remote_command` setpoint into bin by `cmd.mode`.
-- [x] Unit tests in `test_controller_runtime.cpp` for heat→cool→heat preserving each bin; mode=Off leaves bins unchanged.
-- [x] Update `ThermostatApp` to track per-mode bins; selector based on `local_mode_`; sync telemetry into matching bin.
-- [x] Unit tests in `test_thermostat_app.cpp` for display-side mode switching restoring previous bin.
-- [x] Update controller firmware NVS persistence and restore-on-boot to two keys (`hvac_heat_sp_c`, `hvac_cool_sp_c`); legacy migration from `hvac_sp_c`.
-- [x] Update MQTT mode/fan command handlers to refresh shadow setpoint from the runtime's matching bin before sending (so a mode change doesn't clobber the new mode's stored bin).
-- [x] Sim: no changes needed — already uses `rt.target_temperature_c()`.
-- [x] `pio run -e native-tests` green (99 tests pass, 4 new).
-- [x] `pio run -e esp32-furnace-controller` green.
-- [x] `pio run -e esp32-furnace-thermostat` green.
+- [ ] Add `#include <esp_task_wdt.h>` to `esp32_controller_main.cpp`.
+- [ ] **TWDT → 15s, explicit:** in `setup()`, call `esp_task_wdt_reconfigure()`
+      (timeout_ms=15000, idle_core_mask = both cores, trigger_panic=true) to make
+      steady-state deterministic regardless of Arduino default.
+- [ ] Keep OTA-restore (`ota_web_updater.cpp:250`) in sync: 5000→15000, restore a
+      watching idle_core_mask (not 0) so the WDT isn't left disabled after OTA.
+- [ ] **HTTP timeout:** `kCtrlHttpTimeoutMs` 8000 → 4000; add
+      `http.setConnectTimeout(kCtrlHttpTimeoutMs)` in both weather fetch fns
+      (bound TCP/TLS connect + handshake, not just read). Single worst-case op
+      ~4s vs 15s TWDT.
+- [ ] **PubSub socket timeout:** `g_ctrl_mqtt.setSocketTimeout(5)` once in `setup()`.
+- [ ] **RTC breadcrumb:** `RTC_NOINIT_ATTR` magic + breadcrumb word; enum
+      {None, WeatherGeocode, WeatherForecast, MqttConnect, Mdns}; set before / clear
+      after each blocking call. On boot: if magic valid capture last breadcrumb,
+      else init (power-on). Reset breadcrumb for new session.
+- [ ] Surface breadcrumb: publish retained `state/wdt_section` next to `reset_reason`;
+      add a HA diagnostic discovery sensor "Controller WDT Section"; log to audit on boot.
+- [ ] `pio run -e native-tests` green (firmware files excluded; sanity check no breakage).
+- [ ] `pio run -e esp32-furnace-controller` green.
+- [ ] OTA-deploy to 192.168.42.57; confirm `state/wdt_section` publishes; monitor for
+      reduced `task_wdt` and read the breadcrumb if a reset occurs.
+
+### Notes / tradeoffs
+- TWDT trips on contiguous *non-yielding CPU* (mainly the TLS handshake), not on
+  socket waits (those block-and-yield, letting idle feed the WDT). So the binding
+  constraint is each HTTP phase's timeout < TWDT. At 4s connect + 4s read, the
+  worst single op is ~4s vs 15s — comfortable margin, and a truly wedged fetch
+  still produces a fast `task_wdt` reset with a "weather_*" breadcrumb (the
+  weather-wedge graceful watchdog is ~30 min, far slower).
+- RTC_NOINIT survives watchdog/panic/SW resets, not power-on/brownout — handled by magic check.
+- Breadcrumb is per-core (array indexed by xPortGetCoreID), eliminating the
+  cross-core race so the recovered section is unambiguous about which core stalled.
+- Confirmed root cause via PubSubClient.cpp:257 — `connect()` busy-spins on
+  `while(!available())` with no yield for up to socketTimeout; default 15s → 15s
+  core-1 CPU starvation → trips old 5s TWDT. socketTimeout→5s + TWDT→15s fixes it.
 
 ### Review
-- **ControllerRuntime** (`include/controller/controller_runtime.h`, `src/controller/controller_runtime.cpp`): replaced single `target_temperature_c_` with `heat_setpoint_c_` (default 20°C) and `cool_setpoint_c_` (default 24°C). `target_temperature_c()` now returns the bin matching `mode_` (Cool→cool, Heat/Off→heat). `apply_remote_command` routes the incoming setpoint into the bin matching `cmd.mode`; for `cmd.mode == Off` both bins are preserved.
-- **ThermostatApp** (`include/thermostat/thermostat_app.h`, `src/thermostat/thermostat_app.cpp`): mirrored the per-mode model on the display side. `set_local_setpoint_c` writes into the bin for the active mode. Telemetry/state callbacks route incoming setpoint into the bin matching the telemetry's mode (so each bin learns its value when the controller next reports that mode). `send_command` uses `local_setpoint_c()` (active bin).
-- **Controller firmware** (`src/esp32_controller_main.cpp`): NVS keys split into `hvac_heat_sp_c` and `hvac_cool_sp_c` with one-time migration seeded from legacy `hvac_sp_c`. `cmd/mode` and `cmd/fan_mode` MQTT handlers now refresh the shadow setpoint from the runtime's matching bin before sending, so MQTT-initiated mode changes preserve the destination mode's stored bin. `cmd/target_temp_c` still flows the new value through unchanged (it correctly targets the active mode's bin via the existing CommandWord pathway).
-- **Wire format**: unchanged. Protocol version unchanged. Single setpoint field on the wire is interpreted as "setpoint for the mode in this packet."
-- **Tests added**: `controller_runtime_per_mode_setpoints_preserved_across_mode_switch`, `controller_runtime_off_mode_does_not_overwrite_setpoints`, `thermostat_app_per_mode_setpoints_independent`, `thermostat_app_telemetry_routes_setpoint_into_mode_bin`.
+All changes scoped to the controller; no shared headers touched.
 
-### Manual verification (recommended on hardware)
-- Set heat to 21°C, switch to cool, set 23°C, switch back to heat → expect 21°C; switch to cool → expect 23°C.
-- Reboot controller → both bins should restore from NVS.
-- Existing devices with only `hvac_sp_c` in NVS should migrate to seed both bins on first boot.
+**`src/esp32_controller_main.cpp`**
+- `#include <esp_task_wdt.h>`.
+- `kCtrlHttpTimeoutMs` 8000 → 4000; added `http.setConnectTimeout(kCtrlHttpTimeoutMs)`
+  to both weather fetch fns (bounds TCP+TLS handshake, not just read).
+- New constants `kCtrlTaskWdtTimeoutMs = 15000` and `kCtrlMqttSocketTimeoutS = 5`.
+- `setup()`: explicit `esp_task_wdt_reconfigure()` (15s, idle_core_mask=0x3 both
+  cores, trigger_panic) + `g_ctrl_mqtt.setSocketTimeout(5)`.
+- RTC breadcrumb: `RTC_NOINIT` magic + **per-core** section array (indexed by
+  `xPortGetCoreID()`, so weather/core-0 and MQTT/core-1 never race); set/clear
+  around weather geocode, weather forecast, MQTT connect, mDNS;
+  `ctrl_breadcrumb_recover_on_boot()` reports `core0=… core1=…` (or "none").
+- Surfacing: retained `state/wdt_section`, HA discovery sensor "Controller WDT
+  Section", and a boot audit line when the captured section != "none".
 
-### Follow-up: protocol-level "preserve" flags (forward-compatible infrastructure)
+**`src/ota_web_updater.cpp`**
+- Post-OTA WDT restore 5000/mask=0 → 15000/mask=0x3 (was leaving the watchdog
+  disabled until the next reboot). Kept in sync with the controller steady-state.
 
-The bundled `CommandWord` previously forced every sender to assert mode + fan + setpoint together. That coupling was the reason this feature couldn't be a controller-only fix and why every future "settings semantics" change would require flashing both devices.
+**Verification**
+- `pio run -e native-tests` + `./.pio/build/native-tests/program` → 151/151 pass.
+- `pio run -e esp32-furnace-controller` → SUCCESS, firmware.bin produced.
 
-To unblock controller-only updates in the future, the protocol now carries three independent "preserve" flags (bits 24/25/26 of the packed command). A sender sets the flag for any field it does NOT intend to change; the controller, on decode, leaves that field's stored state untouched. The mode/fan/setpoint payload bits are still populated with the sender's current view — older controllers that don't understand the flags fall back to the previous full-state behavior, so this is backward-compatible without a protocol version bump.
+**Deploy (pending user)**
+- OTA to 192.168.42.57. Per runbook: set HVAC Off + wait 60s before flashing.
+- After boot: confirm `state/wdt_section` publishes ("none" on a clean boot).
+- If a `task_wdt` recurs, the breadcrumb names the culprit (weather_* / mqtt_connect / mdns).
 
-**Sender semantics now:**
-- Display `set_local_mode` → `preserve_fan=true`, `preserve_setpoint=true`
-- Display `set_local_fan_mode` → `preserve_mode=true`, `preserve_setpoint=true`
-- Display `set_local_setpoint_c` → `preserve_mode=true`, `preserve_fan=true`
-- Display `request_filter_reset` → preserve all
-- Controller MQTT `cmd/mode` / `cmd/fan_mode` / `cmd/target_temp_c` → preserve the unaffected fields (mirrors display semantics)
-- Controller MQTT `cmd/filter_reset` → preserve all
-
-**Controller routing:** if `preserve_setpoint=false`, the new setpoint is routed into the bin matching the *resolved* mode (i.e. the mode after preserve_mode handling), so a setpoint-only update from a display whose view of mode disagrees with the controller still lands in the controller-authoritative bin.
-
-**Codec:** `codec_preserve_flags_round_trip` test verifies bits round-trip and default is false.
+**Display (`src/thermostat/esp32s3_thermostat_firmware.cpp`)**
+- Same PubSubClient busy-spin in `ensure_mqtt_connected()` (line 1833), runs in the
+  WDT-registered main task → 15s spin starves `esp_task_wdt_reset()` → task_wdt.
+- Fix: `g_mqtt.setSocketTimeout(5)` + `esp_task_wdt_reconfigure()` to 15s
+  (idle_core_mask=0, keeps explicit main+web task watching). No breadcrumb (its
+  explicit task registration already attributes a panic to the main task; 16MB
+  flash likely has a coredump partition — possible future avenue).
+- `pio run -e esp32-furnace-thermostat` → SUCCESS, firmware.bin produced.


### PR DESCRIPTION
## Summary

Both the controller and display intermittently hard-reset with `reset_reason=task_wdt` and `reboot_reason=none`. Root cause (confirmed in `PubSubClient.cpp:257`): `PubSubClient::connect()` busy-waits on the CONNACK in a `while(!available())` loop with **no yield**, for up to `socketTimeout` (default **15s**). That 15s of CPU spin starves the Task Watchdog and panics whenever the broker's CONNACK is slow (marginal WiFi / busy broker) — intermittent, not a tight loop.

The fix bounds every synchronous network timeout well under the watchdog, and adds instrumentation to attribute any residual reset.

## Changes

**Controller (`src/esp32_controller_main.cpp`)**
- Explicitly reconfigure the TWDT to **15s**, watching both idle cores (deterministic, regardless of Arduino default).
- `setSocketTimeout(5)`; weather HTTP timeout **8s → 4s** + `setConnectTimeout()` to bound the TLS handshake.
- Per-core `RTC_NOINIT` **breadcrumb** (set/cleared around weather geocode, weather forecast, MQTT connect, mDNS) that survives a watchdog reset; recovered on boot and surfaced via retained `state/wdt_section`, an HA diagnostic sensor, and the audit log — so a residual `task_wdt` names the blocking section.

**OTA updater (`src/ota_web_updater.cpp`)**
- Post-OTA TWDT restore synced to 15s / both cores (previously left at `mask=0`, i.e. watchdog disabled until reboot).

**Display (`src/thermostat/esp32s3_thermostat_firmware.cpp`)**
- Same PubSubClient spin in the TWDT-registered main task. Fix: `setSocketTimeout(5)` + raise its TWDT timeout to **15s** (`idle_core_mask=0`, preserving its existing explicit main+web task registration).

## Test plan

- [x] `pio run -e native-tests` + run binary → 151/151 pass
- [x] `pio run -e esp32-furnace-controller` → builds clean
- [x] `pio run -e esp32-furnace-thermostat` → builds clean
- [ ] OTA deploy to controller (192.168.42.57) — set HVAC Off + wait 60s before flashing
- [ ] OTA deploy to display (192.168.42.98)
- [ ] Confirm `state/wdt_section` publishes ("none" on a clean boot)
- [ ] Monitor boot_count / reset_reason over several days for reduced `task_wdt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)