### PR TITLE
fix(controller): weather-wedge watchdog spuriously reboots on MQTT reconnect bursts

### DIFF
--- a/include/controller/weather_watchdog.h
+++ b/include/controller/weather_watchdog.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace thermostat {
+
+// Decide whether the weather task's heartbeat is stale enough to consider the task
+// wedged (and therefore in need of recovery).
+//
+// Uses SIGNED arithmetic on the millis() difference. This matters because `now_ms` is
+// captured once at the top of the main loop, but `heartbeat_ms` is written concurrently
+// by the weather task on the other core. If the loop blocks between capturing `now_ms`
+// and calling this (e.g. an MQTT (re)connect that does a connect + a burst of subscribes
+// and retained publishes, which can take hundreds of ms to seconds), the weather task
+// can update `heartbeat_ms` to a value GREATER than the now-stale `now_ms`. With unsigned
+// arithmetic `(uint32_t)(now_ms - heartbeat_ms)` would then underflow to ~4.29e9 and
+// spuriously exceed any threshold — falsely declaring the task wedged and rebooting the
+// device. Signed arithmetic yields a small NEGATIVE age in that case, correctly treating
+// a "future" heartbeat as fresh. It is also millis()-wraparound safe for ages < ~24 days
+// (the threshold here is ~30 min).
+//
+// heartbeat_ms == 0 means the task has not started yet → never wedged.
+inline bool weather_heartbeat_wedged(uint32_t now_ms, uint32_t heartbeat_ms,
+                                     uint32_t threshold_ms) {
+  if (heartbeat_ms == 0) return false;
+  return static_cast<int32_t>(now_ms - heartbeat_ms) >
+         static_cast<int32_t>(threshold_ms);
+}
+
+}  // namespace thermostat

--- a/src/esp32_controller_main.cpp
+++ b/src/esp32_controller_main.cpp
@@ -9,6 +9,7 @@
 #include "controller/controller_relay_io.h"
 #include "controller/controller_node.h"
 #include "controller/pirateweather.h"
+#include "controller/weather_watchdog.h"
 #include "weather_icon.h"
 #include "command_builder.h"
 #include "espnow_cmd_word.h"
@@ -864,9 +865,8 @@ void ctrl_poll_weather(uint32_t now_ms) {
   // likely wedged on a hung TLS/SSL call that ignored the HTTP timeout. Kill
   // and restart it.
   if (g_ctrl_weather_task_handle != nullptr &&
-      g_ctrl_weather_task_heartbeat_ms != 0 &&
-      static_cast<uint32_t>(now_ms - g_ctrl_weather_task_heartbeat_ms) >
-          kCtrlWeatherTaskWatchdogMs) {
+      thermostat::weather_heartbeat_wedged(now_ms, g_ctrl_weather_task_heartbeat_ms,
+                                           kCtrlWeatherTaskWatchdogMs)) {
     // Forcibly killing the task via vTaskDelete leaks C++ stack objects
     // (HTTPClient, WiFiClientSecure) since their destructors won't run.
     // Rebooting is the only safe recovery from a hung TLS call.

--- a/src/tests/test_weather_watchdog.cpp
+++ b/src/tests/test_weather_watchdog.cpp
@@ -1,0 +1,59 @@
+#if defined(THERMOSTAT_RUN_TESTS)
+#include "controller/weather_watchdog.h"
+#include "test_harness.h"
+
+using thermostat::weather_heartbeat_wedged;
+
+// ~30 min, matching the firmware's kCtrlWeatherTaskWatchdogMs (2*15min + 2*4s).
+static const uint32_t kThreshold = 2u * 15u * 60u * 1000u + 2u * 4000u;  // 1,808,000
+
+TEST_CASE(weather_wd_fresh_not_wedged) {
+  // now == heartbeat -> age 0 -> not wedged.
+  ASSERT_TRUE(!weather_heartbeat_wedged(500000u, 500000u, kThreshold));
+}
+
+TEST_CASE(weather_wd_below_threshold_not_wedged) {
+  // 10 min stale, threshold ~30 min -> not wedged.
+  ASSERT_TRUE(!weather_heartbeat_wedged(1100000u, 500000u, kThreshold));
+}
+
+TEST_CASE(weather_wd_heartbeat_ahead_of_now_not_wedged) {
+  // THE BUG: heartbeat updated concurrently to a value GREATER than the stale now_ms.
+  // Unsigned math would underflow to ~4.29e9 and falsely report wedged; signed math
+  // yields a small negative age -> fresh.
+  ASSERT_TRUE(!weather_heartbeat_wedged(730000u, 733500u, kThreshold));  // 3.5s ahead
+  ASSERT_TRUE(!weather_heartbeat_wedged(730000u, 730001u, kThreshold));  // 1ms ahead
+}
+
+TEST_CASE(weather_wd_real_stale_is_wedged) {
+  // Genuinely stale: heartbeat frozen far in the past -> wedged.
+  ASSERT_TRUE(weather_heartbeat_wedged(2'000'000u, 100'000u, kThreshold));  // ~31.7 min old
+}
+
+TEST_CASE(weather_wd_exact_threshold_not_wedged) {
+  // Strictly greater-than: age == threshold is NOT yet wedged.
+  ASSERT_TRUE(!weather_heartbeat_wedged(100000u + kThreshold, 100000u, kThreshold));
+  // One ms past threshold -> wedged.
+  ASSERT_TRUE(weather_heartbeat_wedged(100001u + kThreshold, 100000u, kThreshold));
+}
+
+TEST_CASE(weather_wd_zero_heartbeat_not_wedged) {
+  // Task not started yet (heartbeat 0) -> never wedged, even at large now.
+  ASSERT_TRUE(!weather_heartbeat_wedged(5'000'000u, 0u, kThreshold));
+}
+
+TEST_CASE(weather_wd_millis_wraparound_real_stale) {
+  // now_ms wrapped past 0; heartbeat was just before the wrap. Real age slightly over
+  // threshold -> wedged, handled by signed arithmetic.
+  const uint32_t hb = 0xFFFFFFFFu - 100000u;        // 100s before wrap
+  const uint32_t now = hb + kThreshold + 5000u;     // ~5s past threshold (wraps through 0)
+  ASSERT_TRUE(weather_heartbeat_wedged(now, hb, kThreshold));
+}
+
+TEST_CASE(weather_wd_millis_wraparound_fresh) {
+  // Same wrap region but well within threshold -> not wedged.
+  const uint32_t hb = 0xFFFFFFFFu - 100000u;
+  const uint32_t now = hb + 60000u;  // 60s later, wraps through 0
+  ASSERT_TRUE(!weather_heartbeat_wedged(now, hb, kThreshold));
+}
+#endif  // THERMOSTAT_RUN_TESTS


### PR DESCRIPTION
## Summary
The weather-task **wedge watchdog** can spuriously reboot the controller during normal MQTT reconnects. It compares the loop-top `now` against the weather task's heartbeat with **unsigned** arithmetic:

- `now` is captured once at the top of `loop()`.
- The heartbeat is updated **concurrently** by the weather task on the other core.
- An MQTT (re)connect **blocks the loop** (connect + ~19 subscribes + a retained discovery/state publish burst — hundreds of ms to seconds).
- During that block the weather task pushes the heartbeat **ahead** of the now-stale `now`, so `(uint32_t)(now - heartbeat)` underflows to ~4.29e9, exceeds the ~30-min threshold, and triggers a spurious `esp_restart` (`reboot_reason="weather_wedge: ... heartbeat stale"`, `reset_reason=software`, `panic_pc=none`).

On marginal WiFi (frequent reconnects) this masquerades as the weather task "wedging" and can take the device offline repeatedly — a strong candidate for the long-standing *"weather task keeps wedging, device fails for ~30 min"* symptom.

## Fix
Extract the staleness check into a pure, native-tested `weather_heartbeat_wedged()` (`include/controller/weather_watchdog.h`) using **signed** `millis()` arithmetic — the same wrap-safe idiom as `NetworkRecoveryPolicy`:
- heartbeat momentarily **ahead** of `now` → small negative age → **fresh** (no spurious reboot)
- genuine staleness → large positive age → **wedged** (real recovery still fires)
- `millis()` wraparound stays handled

## Test Plan
- [x] 8 new native unit tests (incl. the exact heartbeat-ahead-of-now case, threshold boundary, zero-heartbeat, and wraparound) — `native-tests` pass
- [x] `esp32-furnace-controller` (classic/production) builds clean
- [x] Reproduced + verified on ESP32-S3 bench hardware: unpatched firmware rebooted on the first MQTT reconnect burst; patched firmware survived 4 outage/recovery cycles with **zero** spurious reboots

## Notes
- Found during on-device resilience validation of the ESP32-S3 port branch (PR #33); this is the non-board-specific subset, fast-tracked to `main` so the production classic controller gets the fix now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)