### PR TITLE
fix(controller): bound weather TLS handshake timeout (8s, was 120s default)

### DIFF
--- a/src/esp32_controller_main.cpp
+++ b/src/esp32_controller_main.cpp
@@ -149,6 +149,12 @@ constexpr uint32_t kCtrlWeatherPollMs = 15UL * 60UL * 1000UL;
 // Watchdog timeout (kCtrlTaskWdtTimeoutMs) so a stalled fetch aborts long before
 // the watchdog would panic.
 constexpr uint32_t kCtrlHttpTimeoutMs = 4000;
+// Bound the TLS handshake for weather HTTPS fetches. WiFiClientSecure defaults to a
+// 120s handshake timeout, so a stalled handshake could block the weather task for up to
+// two minutes. Cap it to a few seconds so a failed handshake returns promptly (the fetch
+// just fails and retries next poll) instead of leaving the task apparently "wedged".
+// Given in SECONDS (NetworkClientSecure::setHandshakeTimeout multiplies by 1000).
+constexpr uint32_t kCtrlTlsHandshakeTimeoutS = 8;
 // Steady-state Task Watchdog timeout. Set explicitly in setup() (and mirrored in
 // ota_web_updater.cpp's post-OTA restore) so behavior is deterministic regardless
 // of the Arduino default. Must exceed every synchronous network timeout above.
@@ -723,6 +729,7 @@ bool ctrl_fetch_zip_coordinates(const char *zip, float *lat_out, float *lon_out)
   if (lat_out == nullptr || lon_out == nullptr || zip[0] == '\0') return false;
   WiFiClientSecure client;
   client.setInsecure();
+  client.setHandshakeTimeout(kCtrlTlsHandshakeTimeoutS);  // bound TLS handshake (default 120s)
   HTTPClient http;
   const std::string url = pirateweather::geocode_url(zip);
   if (!http.begin(client, url.c_str())) {
@@ -754,6 +761,7 @@ bool ctrl_fetch_pirateweather_current(float lat, float lon, const char *api_key,
   }
   WiFiClientSecure client;
   client.setInsecure();
+  client.setHandshakeTimeout(kCtrlTlsHandshakeTimeoutS);  // bound TLS handshake (default 120s)
   HTTPClient http;
   const std::string url = pirateweather::forecast_url(api_key, lat, lon);
   if (!http.begin(client, url.c_str())) {


### PR DESCRIPTION
## Summary
`WiFiClientSecure` defaults to a **120 s** handshake timeout, so a stalled TLS handshake during a weather HTTPS fetch could block the weather task for up to two minutes. This caps it to **8 s** via `setHandshakeTimeout()` in both `ctrl_fetch_zip_coordinates` and `ctrl_fetch_pirateweather_current`, so a failed handshake returns promptly (the fetch fails and retries next poll) instead of leaving the task apparently "wedged".

The fetch's `WiFiClientSecure`/`HTTPClient` objects are stack-local, so a timed-out call returns and destructs cleanly.

## Context
Defense-in-depth on top of the already-shipped weather-wedge **signed-comparison fix (#34)**, which addressed the actual cause of the "weather task wedging / 30-min outage" reports (an unsigned `millis()` underflow that spuriously tripped the wedge watchdog during MQTT reconnect bursts). A single fetch was already bounded to ~120 s + 4 s, so it could not truly hang for 30 min — but tightening the handshake bound is good hygiene and reduces the worst-case weather-task block.

## Test Plan
- [x] `esp32-furnace-controller` (production) builds clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)